### PR TITLE
Fix cljs compilation warning

### DIFF
--- a/src/fluree/json_ld/impl/expand.cljc
+++ b/src/fluree/json_ld/impl/expand.cljc
@@ -186,7 +186,7 @@
 
 
 (defn- type-sub-context
-  "@context can define sub-contexts for certain @type values. Check if exists and merge."
+  "The @context can define sub-contexts for certain @type values. Check if exists and merge."
   [context types]
   (reduce
     (fn [context* type]


### PR DESCRIPTION
When using this library as a cljs dependency, the cljs compiler emits this warning:

"Parse error. illegal use of unknown JSDoc tag "context"; ignoring it. Place another character before the @ to stop JSCompiler from parsing it as an annotation."

This fixes that.