### PR TITLE
json-ld processor api

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,10 @@
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure       {:mvn/version "1.11.1"}
-        org.clojure/clojurescript {:mvn/version "1.11.60"}}
+ :deps {org.clojure/clojure             {:mvn/version "1.11.1"}
+        org.clojure/clojurescript       {:mvn/version "1.11.60"}
+        com.apicatalog/titanium-json-ld {:mvn/version "1.3.1"}
+        org.glassfish/jakarta.json      {:mvn/version "2.0.1"}
+        metosin/jsonista                {:mvn/version "0.3.6"}}
 
  :aliases
  {:mvn/group-id    com.fluree
@@ -14,7 +17,7 @@
                  cheshire/cheshire           {:mvn/version "5.10.1"}
                  thheller/shadow-cljs        {:mvn/version "2.20.5"}}
    :main-opts   ["-e" "(require,'user)"
-               "-e" "(in-ns,'user)"]}
+                 "-e" "(in-ns,'user)"]}
 
   :test
   {:extra-paths ["test"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "jsonld": "^8.1.0"
+      },
       "devDependencies": {
         "karma": "6.4.0",
         "karma-chrome-launcher": "3.1.1",
@@ -18,6 +21,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-3.2.0.tgz",
+      "integrity": "sha512-NhYXcWE/JDE7AnJikNX7q0S6zNuUPA2NuIoRdUpmvHlarjmRqyr6hIO3Awu2FxlUzbdiI1uzuWrZyB9mD1tTvw==",
+      "dependencies": {
+        "ky": "^0.30.0",
+        "ky-universal": "^0.10.1",
+        "undici": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -43,6 +59,17 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
       "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -349,6 +376,17 @@
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "dev": true
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -370,6 +408,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -577,6 +620,14 @@
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -807,6 +858,14 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -837,6 +896,28 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -904,6 +985,17 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -1257,6 +1349,20 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonld": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.1.0.tgz",
+      "integrity": "sha512-6tYhiEVYO3rTcoYCGCArw8SqawuW0hf/cqmaE5WbX44CGb7d8N2UFvmUj9OYkJhChD98bfdPljUj7S39MrzsHg==",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^3.2.0",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/karma": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.0.tgz",
@@ -1319,6 +1425,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ky": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.30.0.tgz",
+      "integrity": "sha512-X/u76z4JtDVq10u1JA5UQfatPxgPaVDMYTrgHyiTpGN2z4TMEJkIHsoSBBSg9SWZEIXTKsi9kHgiQ9o3Y/4yog==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/ky-universal": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.10.1.tgz",
+      "integrity": "sha512-r8909k+ELKZAxhVA5c440x22hqw5XcMRwLRbgpPQk4JHy3/ddJnvzcnSo5Ww3HdKdNeS3Y8dBgcIYyVahMa46g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky-universal?sponsor=1"
+      },
+      "peerDependencies": {
+        "ky": ">=0.26.0",
+        "web-streams-polyfill": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "web-streams-polyfill": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1363,6 +1504,17 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -1494,6 +1646,41 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-libs-browser": {
@@ -1779,6 +1966,17 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rdf-canonize": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.3.0.tgz",
+      "integrity": "sha512-gfSNkMua/VWC1eYbSkVaL/9LQhFeOh0QULwv7Or0f+po8pMgQ1blYQFe1r9Mv2GJZXw88Cz/drnAnB9UlNnHfQ==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1905,8 +2103,7 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2136,6 +2333,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2260,6 +2465,17 @@
         "node": "*"
       }
     },
+    "node_modules/undici": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -2348,6 +2564,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -2422,6 +2646,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -2457,6 +2686,16 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true
     },
+    "@digitalbazaar/http-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-3.2.0.tgz",
+      "integrity": "sha512-NhYXcWE/JDE7AnJikNX7q0S6zNuUPA2NuIoRdUpmvHlarjmRqyr6hIO3Awu2FxlUzbdiI1uzuWrZyB9mD1tTvw==",
+      "requires": {
+        "ky": "^0.30.0",
+        "ky-universal": "^0.10.1",
+        "undici": "^5.2.0"
+      }
+    },
     "@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
@@ -2480,6 +2719,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
       "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.8",
@@ -2747,6 +2994,14 @@
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "dev": true
     },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -2762,6 +3017,11 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
+    },
+    "canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
     },
     "chokidar": {
       "version": "3.5.3",
@@ -2942,6 +3202,11 @@
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
     },
     "date-format": {
       "version": "4.0.14",
@@ -3130,6 +3395,11 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -3157,6 +3427,15 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -3204,6 +3483,14 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -3473,6 +3760,17 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonld": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.1.0.tgz",
+      "integrity": "sha512-6tYhiEVYO3rTcoYCGCArw8SqawuW0hf/cqmaE5WbX44CGb7d8N2UFvmUj9OYkJhChD98bfdPljUj7S39MrzsHg==",
+      "requires": {
+        "@digitalbazaar/http-client": "^3.2.0",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.0.0"
+      }
+    },
     "karma": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.0.tgz",
@@ -3528,6 +3826,20 @@
       "integrity": "sha512-fd4aLynTv3htQCUS+OV1HfoB9UqYfEVFruKxkfTE3zB2aoSCHD966ZitSSgUeVYahWiaCK0XHZp9cB39t65cLQ==",
       "dev": true
     },
+    "ky": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.30.0.tgz",
+      "integrity": "sha512-X/u76z4JtDVq10u1JA5UQfatPxgPaVDMYTrgHyiTpGN2z4TMEJkIHsoSBBSg9SWZEIXTKsi9kHgiQ9o3Y/4yog=="
+    },
+    "ky-universal": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.10.1.tgz",
+      "integrity": "sha512-r8909k+ELKZAxhVA5c440x22hqw5XcMRwLRbgpPQk4JHy3/ddJnvzcnSo5Ww3HdKdNeS3Y8dBgcIYyVahMa46g==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.2.2"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -3562,6 +3874,14 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "md5.js": {
@@ -3667,6 +3987,21 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      }
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -3901,6 +4236,14 @@
         "unpipe": "1.0.0"
       }
     },
+    "rdf-canonize": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.3.0.tgz",
+      "integrity": "sha512-gfSNkMua/VWC1eYbSkVaL/9LQhFeOh0QULwv7Or0f+po8pMgQ1blYQFe1r9Mv2GJZXw88Cz/drnAnB9UlNnHfQ==",
+      "requires": {
+        "setimmediate": "^1.0.5"
+      }
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -4000,8 +4343,7 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -4186,6 +4528,11 @@
         }
       }
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4276,6 +4623,14 @@
       "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
       "dev": true
     },
+    "undici": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -4353,6 +4708,11 @@
       "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
       "dev": true
     },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4397,6 +4757,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
     "karma-chrome-launcher": "3.1.1",
     "karma-cljs-test": "0.1.0",
     "shadow-cljs": "2.20.5"
+  },
+  "dependencies": {
+    "jsonld": "^8.1.0"
   }
 }

--- a/src/fluree/json_ld/processor/api.cljc
+++ b/src/fluree/json_ld/processor/api.cljc
@@ -6,7 +6,7 @@
                    (com.apicatalog.jsonld.document JsonDocument RdfDocument)
                    (java.io StringReader))))
 
-#?(:clojure (set! *warn-on-reflection* true))
+#?(:clj (set! *warn-on-reflection* true))
 
 #?(:clj
    (defn- ->json-document
@@ -127,19 +127,6 @@
      (-> json-ld
          (clj->js)
          (jldjs/toRDF #js {"format" "application/n-quads"}))))
-
-#?(:cljs
-   (comment
-     (-> commit
-         (clj->js)
-         (jldjs/expand)
-         (.then (fn [x] (println "result" (js->clj x)))))
-
-
-
-
-     ,))
-
 
 (comment
   (def context {"message"     "fluree:message",

--- a/src/fluree/json_ld/processor/api.cljc
+++ b/src/fluree/json_ld/processor/api.cljc
@@ -1,0 +1,274 @@
+(ns fluree.json-ld.processor.api
+  (:refer-clojure :exclude [flatten])
+  (:require [jsonista.core :as json])
+  #?(:clj (:import (com.apicatalog.jsonld JsonLd)
+                   (com.apicatalog.jsonld.document JsonDocument RdfDocument)
+                   (java.io StringReader))))
+
+#?(:clojure (set! *warn-on-reflection* true))
+
+#?(:clj
+   (defn- ->json-document
+     [edn]
+     (-> edn
+         (json/write-value-as-string)
+         (StringReader.)
+         (JsonDocument/of))))
+
+#?(:clj
+   (defn- ->rdf-document
+     [nquads]
+     (-> nquads
+         (StringReader.)
+         (RdfDocument/of))))
+
+#?(:clj
+   (defn- ->edn
+     [json-ld-api]
+     (-> json-ld-api
+         (.get)
+         (.toString)
+         (json/read-value))))
+
+(defn expand
+  [json-ld]
+  #?(:clj
+     (-> json-ld
+         (->json-document)
+         (JsonLd/expand)
+         (->edn))))
+
+(defn compact
+  [json-ld context]
+  #?(:clj
+     (-> json-ld
+         (->json-document)
+         (JsonLd/compact (->json-document context))
+         (->edn))))
+
+(defn flatten
+  [json-ld]
+  #?(:clj
+     (-> json-ld
+         (->json-document json-ld)
+         (JsonLd/flatten)
+         (->edn))))
+
+(defn from-rdf
+  [n-quads]
+  #?(:clj
+     (-> n-quads
+         (->rdf-document)
+         (JsonLd/fromRdf)
+         (->edn))))
+
+#?(:clj
+   (defn- ->statement
+     [quad]
+     (str (let [subject (.getSubject quad)]
+            (if (.isIRI subject)
+              (str "<" (.toString subject) ">")
+              (.toString subject)))
+          " "
+          (let [predicate (.getPredicate quad)]
+            (if (.isIRI predicate)
+              (str "<" (.toString predicate) ">")
+              (.toString predicate)))
+          " "
+          (let [object (.getObject quad)]
+            (cond (.isIRI object)
+                  (str "<" (.toString object) ">")
+                  (.isLiteral object)
+                  (let [datatype (.getDatatype object)
+                        lang (.getLanguage object)
+                        value (.getValue object)]
+                    (str "\"" value "\""
+                         (if (.isPresent lang)
+                           (str "@" (.get lang))
+                           (when (not= "http://www.w3.org/2001/XMLSchema#string" datatype)
+                             (str "^^<" datatype ">")))))
+                  :else
+                  (.toString object)))
+          " .")))
+
+(defn to-rdf
+  [json-ld]
+  #?(:clj
+     (-> json-ld
+         (->json-document)
+         (JsonLd/toRdf)
+         (.get)
+         (.toList)
+         (->> (map ->statement)
+              (reduce (fn [doc statement] (str doc statement "\n")) "")))))
+
+#(:clj
+  (comment
+
+    (def context {"message"     "fluree:message",
+                  "role"        {"@id" "fluree:role", "@type" "@id"},
+                  "Index"       "fluree:Index",
+                  "index"       "fluree:index",
+                  "opsTransact" "fluree:opsTransact",
+                  "Context"     "fluree:Context",
+                  "updates"     "fluree:updates",
+                  "branch"      "fluree:branch",
+                  "issuer"      {"@id" "fluree:issuer", "@type" "@id"},
+                  "FNS"         "fluree:FNS",
+                  "DB"          "fluree:DB",
+                  "v"           {"@id" "fluree:v", "@type" "xsd:decimal"},
+                  "id"          "@id",
+                  "flakes"      {"@id" "fluree:flakes", "@type" "xsd:long"},
+                  "Role"        "fluree:Role",
+                  "Commit"      "fluree:Commit",
+                  "allTypes"    "fluree:allTypes",
+                  "tag"         "fluree:tag",
+                  "commit"      {"@id" "fluree:commit", "@type" "@id"},
+                  "@version"    1.1,
+                  "rules"       {"@id" "fluree:rules", "@type" "@id"},
+                  "context"     "fluree:context",
+                  "address"     "fluree:address",
+                  "previous"    {"@id" "fluree:previous", "@type" "@id"},
+                  "fluree"      "https://ns.flur.ee/ledger#",
+                  "opsQuery"    "fluree:opsQuery",
+                  "retract"     {"@id" "fluree:retract", "@container" "@graph"},
+                  "functions"   {"@id" "fluree:function", "@type" "@id"},
+                  "time"        "fluree:time",
+                  "t"           {"@id" "fluree:t", "@type" "xsd:long"},
+                  "rdfs"        "http://www.w3.org/2000/01/rdf-schema#",
+                  "opsAll"      "fluree:opsAll",
+                  "Rule"        "fluree:Rule",
+                  "tx"          {"@id" "fluree:tx", "@type" "@id"},
+                  "type"        "@type",
+                  "DID"         "fluree:DID",
+                  "alias"       "fluree:alias",
+                  "size"        {"@id" "fluree:size", "@type" "xsd:long"},
+                  "Function"    "fluree:Function",
+                  "CommitProof" "fluree:CommitProof",
+                  "data"        {"@id" "fluree:data", "@type" "@id"},
+                  "skos"        "http://www.w3.org/2008/05/skos#",
+                  "code"        "fluree:code",
+                  "assert"      {"@id" "fluree:assert", "@container" "@graph"},
+                  "ns"          {"@id" "fluree:ns", "@type" "@id"},
+                  "ledger"      "fluree:ledger",
+                  "xsd"         "http://www.w3.org/2001/XMLSchema#",
+                  "operations"  {"@id" "fluree:operations", "@type" "@id"}})
+
+    (def commit
+      {"@context" context
+       "branch"   "main",
+       "issuer"   {"id" "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"},
+       "v"        0,
+       "id"       "fluree:commit:sha256:bbr7bbot7cjhbrtcye6inc2zxecfy7zh3ooba5caw6vfkdkbf5uxp",
+       "address"  "",
+       "time"     "2022-11-07T15:18:55.171018Z",
+       "type"     ["Commit"],
+       "alias"    {"@value" "test/db19" "@language" "en"},
+       "data"
+       {"id"     "fluree:db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
+        "type"   ["DB"],
+        "t"      1,
+        "address"
+        "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569",
+        "flakes" 55,
+        "size"   5057}})
+
+
+    (from-rdf (to-rdf commit))
+
+
+    [{"@id"
+      "https://ns.flur.ee/ledger#commit:sha256:bbr7bbot7cjhbrtcye6inc2zxecfy7zh3ooba5caw6vfkdkbf5uxp",
+      "https://ns.flur.ee/ledger#branch"  [{"@value" "main"}],
+      "https://ns.flur.ee/ledger#address" [{"@value" ""}],
+      "https://ns.flur.ee/ledger#alias"   [{"@language" "en", "@value" "test/db19"}],
+      "https://ns.flur.ee/ledger#v"
+      [{"@value" "0", "@type" "http://www.w3.org/2001/XMLSchema#decimal"}],
+      "https://ns.flur.ee/ledger#time"    [{"@value" "2022-11-07T15:18:55.171018Z"}],
+      "https://ns.flur.ee/ledger#issuer"
+      [{"@id" "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"}],
+      "https://ns.flur.ee/ledger#data"
+      [{"@id"
+        "https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6"}],
+      "@type"                             ["https://ns.flur.ee/ledger#Commit"]}
+     {"https://ns.flur.ee/ledger#size"
+      [{"@value" "5057", "@type" "http://www.w3.org/2001/XMLSchema#long"}],
+      "@id"
+      "https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
+      "https://ns.flur.ee/ledger#t"
+      [{"@value" "1", "@type" "http://www.w3.org/2001/XMLSchema#long"}],
+      "https://ns.flur.ee/ledger#flakes"
+      [{"@value" "55", "@type" "http://www.w3.org/2001/XMLSchema#long"}],
+      "https://ns.flur.ee/ledger#address"
+      [{"@value"
+        "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569"}],
+      "@type" ["https://ns.flur.ee/ledger#DB"]}]
+
+    (compact (expand commit) context)
+    {"@context"
+     {"message"     "fluree:message",
+      "role"        {"@id" "fluree:role", "@type" "@id"},
+      "Index"       "fluree:Index",
+      "index"       "fluree:index",
+      "opsTransact" "fluree:opsTransact",
+      "Context"     "fluree:Context",
+      "updates"     "fluree:updates",
+      "branch"      "fluree:branch",
+      "issuer"      {"@id" "fluree:issuer", "@type" "@id"},
+      "FNS"         "fluree:FNS",
+      "DB"          "fluree:DB",
+      "v"           {"@id" "fluree:v", "@type" "xsd:decimal"},
+      "id"          "@id",
+      "flakes"      {"@id" "fluree:flakes", "@type" "xsd:long"},
+      "Role"        "fluree:Role",
+      "Commit"      "fluree:Commit",
+      "allTypes"    "fluree:allTypes",
+      "tag"         "fluree:tag",
+      "commit"      {"@id" "fluree:commit", "@type" "@id"},
+      "@version"    1.1,
+      "rules"       {"@id" "fluree:rules", "@type" "@id"},
+      "context"     "fluree:context",
+      "address"     "fluree:address",
+      "previous"    {"@id" "fluree:previous", "@type" "@id"},
+      "fluree"      "https://ns.flur.ee/ledger#",
+      "opsQuery"    "fluree:opsQuery",
+      "retract"     {"@id" "fluree:retract", "@container" "@graph"},
+      "functions"   {"@id" "fluree:function", "@type" "@id"},
+      "time"        "fluree:time",
+      "t"           {"@id" "fluree:t", "@type" "xsd:long"},
+      "rdfs"        "http://www.w3.org/2000/01/rdf-schema#",
+      "opsAll"      "fluree:opsAll",
+      "Rule"        "fluree:Rule",
+      "tx"          {"@id" "fluree:tx", "@type" "@id"},
+      "type"        "@type",
+      "DID"         "fluree:DID",
+      "alias"       "fluree:alias",
+      "size"        {"@id" "fluree:size", "@type" "xsd:long"},
+      "Function"    "fluree:Function",
+      "CommitProof" "fluree:CommitProof",
+      "data"        {"@id" "fluree:data", "@type" "@id"},
+      "skos"        "http://www.w3.org/2008/05/skos#",
+      "code"        "fluree:code",
+      "assert"      {"@id" "fluree:assert", "@container" "@graph"},
+      "ns"          {"@id" "fluree:ns", "@type" "@id"},
+      "ledger"      "fluree:ledger",
+      "xsd"         "http://www.w3.org/2001/XMLSchema#",
+      "operations"  {"@id" "fluree:operations", "@type" "@id"}},
+     "branch"  "main",
+     "issuer"  "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh",
+     "v"       0,
+     "id"      "fluree:commit:sha256:bbr7bbot7cjhbrtcye6inc2zxecfy7zh3ooba5caw6vfkdkbf5uxp",
+     "address" "",
+     "time"    "2022-11-07T15:18:55.171018Z",
+     "type"    "Commit",
+     "alias"   {"@language" "en", "@value" "test/db19"},
+     "data"
+     {"id"     "fluree:db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
+      "flakes" 55,
+      "address"
+      "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569",
+      "t"      1,
+      "type"   "DB",
+      "size"   5057}}
+
+    ))

--- a/src/fluree/json_ld/processor/api.cljc
+++ b/src/fluree/json_ld/processor/api.cljc
@@ -1,6 +1,7 @@
 (ns fluree.json-ld.processor.api
   (:refer-clojure :exclude [flatten])
-  (:require [jsonista.core :as json])
+  (:require #?(:clj [jsonista.core :as json])
+            #?(:cljs ["jsonld" :as jldjs]))
   #?(:clj (:import (com.apicatalog.jsonld JsonLd)
                    (com.apicatalog.jsonld.document JsonDocument RdfDocument)
                    (java.io StringReader))))
@@ -36,7 +37,13 @@
      (-> json-ld
          (->json-document)
          (JsonLd/expand)
-         (->edn))))
+         (->edn))
+     :cljs
+     (-> commit
+         (clj->js)
+         (jldjs/expand)
+         (.then (fn [result] (js->clj result))))))
+
 
 (defn compact
   [json-ld context]
@@ -44,7 +51,12 @@
      (-> json-ld
          (->json-document)
          (JsonLd/compact (->json-document context))
-         (->edn))))
+         (->edn))
+     :cljs
+     (-> json-ld
+         (clj->js)
+         (jldjs/compact (clj->js context))
+         (.then (fn [result] (js->clj result))))))
 
 (defn flatten
   [json-ld]
@@ -52,7 +64,12 @@
      (-> json-ld
          (->json-document json-ld)
          (JsonLd/flatten)
-         (->edn))))
+         (->edn))
+     :cljs
+     (-> json-ld
+         (clj->js)
+         (jldjs/flatten)
+         (.then (fn [result] (js->clj result))))))
 
 (defn from-rdf
   [n-quads]
@@ -60,7 +77,12 @@
      (-> n-quads
          (->rdf-document)
          (JsonLd/fromRdf)
-         (->edn))))
+         (->edn))
+     :cljs
+     (-> n-quads
+         (clj->js)
+         (jldjs/fromRDF #js {"format" "application/n-quads"})
+         (.then (fn [result] (js->clj result))))))
 
 #?(:clj
    (defn- ->statement
@@ -100,175 +122,130 @@
          (.get)
          (.toList)
          (->> (map ->statement)
-              (reduce (fn [doc statement] (str doc statement "\n")) "")))))
+              (reduce (fn [doc statement] (str doc statement "\n")) "")))
+     :cljs
+     (-> json-ld
+         (clj->js)
+         (jldjs/toRDF #js {"format" "application/n-quads"}))))
 
-#(:clj
-  (comment
-
-    (def context {"message"     "fluree:message",
-                  "role"        {"@id" "fluree:role", "@type" "@id"},
-                  "Index"       "fluree:Index",
-                  "index"       "fluree:index",
-                  "opsTransact" "fluree:opsTransact",
-                  "Context"     "fluree:Context",
-                  "updates"     "fluree:updates",
-                  "branch"      "fluree:branch",
-                  "issuer"      {"@id" "fluree:issuer", "@type" "@id"},
-                  "FNS"         "fluree:FNS",
-                  "DB"          "fluree:DB",
-                  "v"           {"@id" "fluree:v", "@type" "xsd:decimal"},
-                  "id"          "@id",
-                  "flakes"      {"@id" "fluree:flakes", "@type" "xsd:long"},
-                  "Role"        "fluree:Role",
-                  "Commit"      "fluree:Commit",
-                  "allTypes"    "fluree:allTypes",
-                  "tag"         "fluree:tag",
-                  "commit"      {"@id" "fluree:commit", "@type" "@id"},
-                  "@version"    1.1,
-                  "rules"       {"@id" "fluree:rules", "@type" "@id"},
-                  "context"     "fluree:context",
-                  "address"     "fluree:address",
-                  "previous"    {"@id" "fluree:previous", "@type" "@id"},
-                  "fluree"      "https://ns.flur.ee/ledger#",
-                  "opsQuery"    "fluree:opsQuery",
-                  "retract"     {"@id" "fluree:retract", "@container" "@graph"},
-                  "functions"   {"@id" "fluree:function", "@type" "@id"},
-                  "time"        "fluree:time",
-                  "t"           {"@id" "fluree:t", "@type" "xsd:long"},
-                  "rdfs"        "http://www.w3.org/2000/01/rdf-schema#",
-                  "opsAll"      "fluree:opsAll",
-                  "Rule"        "fluree:Rule",
-                  "tx"          {"@id" "fluree:tx", "@type" "@id"},
-                  "type"        "@type",
-                  "DID"         "fluree:DID",
-                  "alias"       "fluree:alias",
-                  "size"        {"@id" "fluree:size", "@type" "xsd:long"},
-                  "Function"    "fluree:Function",
-                  "CommitProof" "fluree:CommitProof",
-                  "data"        {"@id" "fluree:data", "@type" "@id"},
-                  "skos"        "http://www.w3.org/2008/05/skos#",
-                  "code"        "fluree:code",
-                  "assert"      {"@id" "fluree:assert", "@container" "@graph"},
-                  "ns"          {"@id" "fluree:ns", "@type" "@id"},
-                  "ledger"      "fluree:ledger",
-                  "xsd"         "http://www.w3.org/2001/XMLSchema#",
-                  "operations"  {"@id" "fluree:operations", "@type" "@id"}})
-
-    (def commit
-      {"@context" context
-       "branch"   "main",
-       "issuer"   {"id" "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"},
-       "v"        0,
-       "id"       "fluree:commit:sha256:bbr7bbot7cjhbrtcye6inc2zxecfy7zh3ooba5caw6vfkdkbf5uxp",
-       "address"  "",
-       "time"     "2022-11-07T15:18:55.171018Z",
-       "type"     ["Commit"],
-       "alias"    {"@value" "test/db19" "@language" "en"},
-       "data"
-       {"id"     "fluree:db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
-        "type"   ["DB"],
-        "t"      1,
-        "address"
-        "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569",
-        "flakes" 55,
-        "size"   5057}})
+#?(:cljs
+   (comment
+     (-> commit
+         (clj->js)
+         (jldjs/expand)
+         (.then (fn [x] (println "result" (js->clj x)))))
 
 
-    (from-rdf (to-rdf commit))
 
 
-    [{"@id"
-      "https://ns.flur.ee/ledger#commit:sha256:bbr7bbot7cjhbrtcye6inc2zxecfy7zh3ooba5caw6vfkdkbf5uxp",
-      "https://ns.flur.ee/ledger#branch"  [{"@value" "main"}],
-      "https://ns.flur.ee/ledger#address" [{"@value" ""}],
-      "https://ns.flur.ee/ledger#alias"   [{"@language" "en", "@value" "test/db19"}],
-      "https://ns.flur.ee/ledger#v"
-      [{"@value" "0", "@type" "http://www.w3.org/2001/XMLSchema#decimal"}],
-      "https://ns.flur.ee/ledger#time"    [{"@value" "2022-11-07T15:18:55.171018Z"}],
-      "https://ns.flur.ee/ledger#issuer"
-      [{"@id" "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"}],
-      "https://ns.flur.ee/ledger#data"
-      [{"@id"
-        "https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6"}],
-      "@type"                             ["https://ns.flur.ee/ledger#Commit"]}
-     {"https://ns.flur.ee/ledger#size"
-      [{"@value" "5057", "@type" "http://www.w3.org/2001/XMLSchema#long"}],
-      "@id"
-      "https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
-      "https://ns.flur.ee/ledger#t"
-      [{"@value" "1", "@type" "http://www.w3.org/2001/XMLSchema#long"}],
-      "https://ns.flur.ee/ledger#flakes"
-      [{"@value" "55", "@type" "http://www.w3.org/2001/XMLSchema#long"}],
-      "https://ns.flur.ee/ledger#address"
-      [{"@value"
-        "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569"}],
-      "@type" ["https://ns.flur.ee/ledger#DB"]}]
+     ,))
 
-    (compact (expand commit) context)
-    {"@context"
-     {"message"     "fluree:message",
-      "role"        {"@id" "fluree:role", "@type" "@id"},
-      "Index"       "fluree:Index",
-      "index"       "fluree:index",
-      "opsTransact" "fluree:opsTransact",
-      "Context"     "fluree:Context",
-      "updates"     "fluree:updates",
-      "branch"      "fluree:branch",
-      "issuer"      {"@id" "fluree:issuer", "@type" "@id"},
-      "FNS"         "fluree:FNS",
-      "DB"          "fluree:DB",
-      "v"           {"@id" "fluree:v", "@type" "xsd:decimal"},
-      "id"          "@id",
-      "flakes"      {"@id" "fluree:flakes", "@type" "xsd:long"},
-      "Role"        "fluree:Role",
-      "Commit"      "fluree:Commit",
-      "allTypes"    "fluree:allTypes",
-      "tag"         "fluree:tag",
-      "commit"      {"@id" "fluree:commit", "@type" "@id"},
-      "@version"    1.1,
-      "rules"       {"@id" "fluree:rules", "@type" "@id"},
-      "context"     "fluree:context",
-      "address"     "fluree:address",
-      "previous"    {"@id" "fluree:previous", "@type" "@id"},
-      "fluree"      "https://ns.flur.ee/ledger#",
-      "opsQuery"    "fluree:opsQuery",
-      "retract"     {"@id" "fluree:retract", "@container" "@graph"},
-      "functions"   {"@id" "fluree:function", "@type" "@id"},
-      "time"        "fluree:time",
-      "t"           {"@id" "fluree:t", "@type" "xsd:long"},
-      "rdfs"        "http://www.w3.org/2000/01/rdf-schema#",
-      "opsAll"      "fluree:opsAll",
-      "Rule"        "fluree:Rule",
-      "tx"          {"@id" "fluree:tx", "@type" "@id"},
-      "type"        "@type",
-      "DID"         "fluree:DID",
-      "alias"       "fluree:alias",
-      "size"        {"@id" "fluree:size", "@type" "xsd:long"},
-      "Function"    "fluree:Function",
-      "CommitProof" "fluree:CommitProof",
-      "data"        {"@id" "fluree:data", "@type" "@id"},
-      "skos"        "http://www.w3.org/2008/05/skos#",
-      "code"        "fluree:code",
-      "assert"      {"@id" "fluree:assert", "@container" "@graph"},
-      "ns"          {"@id" "fluree:ns", "@type" "@id"},
-      "ledger"      "fluree:ledger",
-      "xsd"         "http://www.w3.org/2001/XMLSchema#",
-      "operations"  {"@id" "fluree:operations", "@type" "@id"}},
-     "branch"  "main",
-     "issuer"  "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh",
-     "v"       0,
-     "id"      "fluree:commit:sha256:bbr7bbot7cjhbrtcye6inc2zxecfy7zh3ooba5caw6vfkdkbf5uxp",
-     "address" "",
-     "time"    "2022-11-07T15:18:55.171018Z",
-     "type"    "Commit",
-     "alias"   {"@language" "en", "@value" "test/db19"},
+
+(comment
+  (def context {"message"     "fluree:message",
+                "role"        {"@id" "fluree:role", "@type" "@id"},
+                "Index"       "fluree:Index",
+                "index"       "fluree:index",
+                "opsTransact" "fluree:opsTransact",
+                "Context"     "fluree:Context",
+                "updates"     "fluree:updates",
+                "branch"      "fluree:branch",
+                "issuer"      {"@id" "fluree:issuer", "@type" "@id"},
+                "FNS"         "fluree:FNS",
+                "DB"          "fluree:DB",
+                "v"           {"@id" "fluree:v", "@type" "xsd:decimal"},
+                "id"          "@id",
+                "flakes"      {"@id" "fluree:flakes", "@type" "xsd:long"},
+                "Role"        "fluree:Role",
+                "Commit"      "fluree:Commit",
+                "allTypes"    "fluree:allTypes",
+                "tag"         "fluree:tag",
+                "commit"      {"@id" "fluree:commit", "@type" "@id"},
+                "@version"    1.1,
+                "rules"       {"@id" "fluree:rules", "@type" "@id"},
+                "context"     "fluree:context",
+                "address"     "fluree:address",
+                "previous"    {"@id" "fluree:previous", "@type" "@id"},
+                "fluree"      "https://ns.flur.ee/ledger#",
+                "opsQuery"    "fluree:opsQuery",
+                "retract"     {"@id" "fluree:retract", "@container" "@graph"},
+                "functions"   {"@id" "fluree:function", "@type" "@id"},
+                "time"        "fluree:time",
+                "t"           {"@id" "fluree:t", "@type" "xsd:long"},
+                "rdfs"        "http://www.w3.org/2000/01/rdf-schema#",
+                "opsAll"      "fluree:opsAll",
+                "Rule"        "fluree:Rule",
+                "tx"          {"@id" "fluree:tx", "@type" "@id"},
+                "type"        "@type",
+                "DID"         "fluree:DID",
+                "alias"       "fluree:alias",
+                "size"        {"@id" "fluree:size", "@type" "xsd:long"},
+                "Function"    "fluree:Function",
+                "CommitProof" "fluree:CommitProof",
+                "data"        {"@id" "fluree:data", "@type" "@id"},
+                "skos"        "http://www.w3.org/2008/05/skos#",
+                "code"        "fluree:code",
+                "assert"      {"@id" "fluree:assert", "@container" "@graph"},
+                "ns"          {"@id" "fluree:ns", "@type" "@id"},
+                "ledger"      "fluree:ledger",
+                "xsd"         "http://www.w3.org/2001/XMLSchema#",
+                "operations"  {"@id" "fluree:operations", "@type" "@id"}})
+
+  (def commit
+    {"@context" context
+     "branch"   "main",
+     "issuer"   {"id" "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"},
+     "v"        0,
+     "id"       "fluree:commit:sha256:bbr7bbot7cjhbrtcye6inc2zxecfy7zh3ooba5caw6vfkdkbf5uxp",
+     "address"  "",
+     "time"     "2022-11-07T15:18:55.171018Z",
+     "type"     ["Commit"],
+     "alias"    {"@value" "test/db19" "@language" "en"},
      "data"
      {"id"     "fluree:db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
-      "flakes" 55,
+      "type"   ["DB"],
+      "t"      1,
       "address"
       "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569",
-      "t"      1,
-      "type"   "DB",
-      "size"   5057}}
+      "flakes" 55,
+      "size"   5057}})
+  )
 
-    ))
+#?(:clj
+   (comment
+
+     (from-rdf (to-rdf commit))
+
+     (compact (expand commit) context)
+
+     ,)
+
+   :cljs
+   (comment
+     (def rdf (atom nil))
+     (-> (to-rdf commit)
+         (.then #(do (reset! rdf %) %)))
+
+     @rdf
+
+     (def jld (atom nil))
+     (-> (from-rdf @rdf)
+         (.then #(do (reset! jld %) %)))
+
+     @jld
+
+     (def expanded (atom nil))
+     (-> (expand commit)
+         (.then #(do (reset! expanded %) %)))
+
+     @expanded
+
+     (def compacted (atom nil))
+     (-> (compact @expanded context)
+         (.then #(do (reset! compacted %) %)))
+
+     @compacted
+
+     ,)
+
+   )


### PR DESCRIPTION
We do some idiosyncratic work in the json-ld library when it comes to expansion, and we don't currently implement other parts of the processor api like toRdf, which is necessary to get canonicalization working. This is a thin wrapper around two officially tested and compliant json-ld processor apis, found from the official implementation reports: https://w3c.github.io/json-ld-api/reports/

This seemed like a much easier route than re-implementing ourselves.