### PR TITLE
static external contexts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 
 SOURCES := $(shell find src)
 
-target/fluree-jsonld.jar: pom.xml deps.edn $(SOURCES)
+target/fluree-json-ld.jar: pom.xml deps.edn src/deps.cljs $(SOURCES)
 	clojure -X:jar
+
+src/deps.cljs: package.json
+	clojure -M:js-deps
 
 pom.xml: deps.edn
 	clojure -Spom

--- a/deps.edn
+++ b/deps.edn
@@ -29,6 +29,10 @@
                   :sha     "b6b3193fcc42659d7e46ecd1884a228993441182"}}
    :main-opts   ["-m" "cognitect.test-runner"]}
 
+  :js-deps
+  {:extra-deps {com.timetraveltoaster/target-bundle-libs {:mvn/version "RELEASE"}}
+   :main-opts  ["-m" "target-bundle-libs.core"]}
+
   :jar
   {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.267"}}
    :exec-fn      hf.depstar/jar

--- a/pom.xml
+++ b/pom.xml
@@ -28,17 +28,42 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.3</version>
+      <version>1.11.1</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojurescript</artifactId>
-      <version>1.10.866</version>
+      <version>1.11.60</version>
     </dependency>
     <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>tools.logging</artifactId>
-      <version>1.1.0</version>
+      <groupId>com.apicatalog</groupId>
+      <artifactId>titanium-json-ld</artifactId>
+      <version>1.3.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.json</artifactId>
+      <version>2.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <dependency>
+      <groupId>io.setl</groupId>
+      <artifactId>rdf-urdna</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>metosin</groupId>
+      <artifactId>jsonista</artifactId>
+      <version>0.3.6</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/fluree/json_ld/impl/external.cljc
+++ b/src/fluree/json_ld/impl/external.cljc
@@ -3,7 +3,7 @@
             [fluree.json-ld.impl.util :as util]
             [clojure.string :as str])
   (:refer-clojure :exclude [read])
-  #?(:cljs (:require-macros [fluree.json-ld.impl.external :refer [inline-files]])))
+  #?(:cljs (:require-macros [fluree.json-ld.impl.external :refer [inline-files inline-json]])))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -77,8 +77,20 @@
                           vocab->file)]
        loaded)))
 
+#?(:clj
+   (defmacro inline-json
+     "The classpath doesn't exist in javascript, so we need to inline all of our resources at
+  compile time so they are available to js applications at runtime."
+     []
+     (reduce (fn [l [url {:keys [source]}]]
+               (assoc l url (util/slurp-resource source)))
+             {}
+             context->file)))
+
 #?(:cljs
    (def inlined-files (inline-files)))
+#?(:cljs
+   (def inlined-contexts (inline-json)))
 
 #?(:cljs
    (defn read-inlined-resource

--- a/src/fluree/json_ld/impl/util.cljc
+++ b/src/fluree/json_ld/impl/util.cljc
@@ -37,21 +37,23 @@
     x
     [x]))
 
-
-(defn read-resource
+(defn slurp-resource
   [filename]
   #?(:cljs (throw (ex-info (str "Loading external resources is not yet supported in Javascript.")
                            {:status 400 :error :json-ld/external-resource}))
      :clj  (try
              (some-> filename
                      io/resource
-                     slurp
-                     edn/read-string)
+                     slurp)
              (catch Exception e
                (throw (ex-info
                         (str "Invalid IRI, unable to read vocabulary from: " filename)
                         {:status 400 :error :json-ld/external-resource}
                         e))))))
+#?(:clj
+   (defn read-resource
+     [filename]
+     (edn/read-string (slurp-resource filename))))
 
 (comment
   (try-catchall
@@ -66,5 +68,5 @@
   nil
   nil
 
-  (read-resource "foo")
+  #_(read-resource "foo")
   )

--- a/src/fluree/json_ld/processor/api.clj
+++ b/src/fluree/json_ld/processor/api.clj
@@ -124,8 +124,13 @@
 
 (defn canonize
   [json-ld]
-  (->> (.toList (RdfNormalize/normalize (.get (JsonLd/toRdf (->json-document json-ld)))))
-       (reduce (fn [doc quad] (str doc (->statement quad) "\n")) "")))
+  (-> (->json-document json-ld)
+      (JsonLd/toRdf)
+      (.loader ^DocumentLoader (->StaticLoader))
+      (.get)
+      (RdfNormalize/normalize)
+      (.toList)
+      (->> (reduce (fn [doc quad] (str doc (->statement quad) "\n")) ""))))
 
 (comment
   ;; These work up to translating the resulting json-ld back into edn

--- a/src/fluree/json_ld/processor/api.clj
+++ b/src/fluree/json_ld/processor/api.clj
@@ -40,24 +40,24 @@
       "null" nil)))
 
 (defn- ->json-document
-     [edn]
-     (-> edn
-         (json/write-value-as-string)
-         (StringReader.)
-         (JsonDocument/of)))
+  ^JsonDocument [edn]
+  (-> edn
+      (json/write-value-as-string)
+      (StringReader.)
+      (JsonDocument/of)))
 
 (defn expand
   [json-ld]
-  (parsed (.get (JsonLd/expand ^JsonDocument (->json-document json-ld)))))
+  (parsed (.get (JsonLd/expand (->json-document json-ld)))))
 
 (defn compact
   [json-ld context]
-  (parsed (.get (JsonLd/compact ^JsonDocument (->json-document json-ld)
-                                ^JsonDocument (->json-document context)))))
+  (parsed (.get (JsonLd/compact (->json-document json-ld)
+                                (->json-document context)))))
 
 (defn flatten
   [json-ld]
-  (parsed (.get (JsonLd/flatten ^JsonDocument (->json-document json-ld)))))
+  (parsed (.get (JsonLd/flatten (->json-document json-ld)))))
 
 (defn- ->statement
   [^RdfNQuad quad]
@@ -90,12 +90,12 @@
 
 (defn to-rdf
   [json-ld]
-  (->> (.toList (.get (JsonLd/toRdf ^JsonDocument (->json-document json-ld))))
+  (->> (.toList (.get (JsonLd/toRdf (->json-document json-ld))))
        (reduce (fn [doc quad] (str doc (->statement quad) "\n")) "")))
 
 (defn canonize
   [json-ld]
-  (->> (.toList (RdfNormalize/normalize (.get (JsonLd/toRdf ^JsonDocument (->json-document json-ld)))))
+  (->> (.toList (RdfNormalize/normalize (.get (JsonLd/toRdf (->json-document json-ld)))))
        (reduce (fn [doc quad] (str doc (->statement quad) "\n")) "")))
 
 (comment

--- a/src/fluree/json_ld/processor/api.clj
+++ b/src/fluree/json_ld/processor/api.clj
@@ -55,7 +55,7 @@
   (loadDocument [_ url options]
     (if-let [{path :source} (external/context->file (.toString url))]
       (-> (FileLoader.)
-          (.loadDocument (URI. (str "file://" (.getAbsolutePath (io/file "")) "/resources/" path))
+          (.loadDocument (.toURI (io/resource path))
                          (DocumentLoaderOptions.)))
       (throw (JsonLdError. JsonLdErrorCode/LOADING_REMOTE_CONTEXT_FAILED
                            (str "Unable to load static context: " (.toString url)))))))

--- a/src/fluree/json_ld/processor/api.clj
+++ b/src/fluree/json_ld/processor/api.clj
@@ -1,10 +1,14 @@
 (ns fluree.json-ld.processor.api
   (:refer-clojure :exclude [flatten])
-  (:require [jsonista.core :as json])
-  (:import (com.apicatalog.jsonld JsonLd)
+  (:require [jsonista.core :as json]
+            [fluree.json-ld.impl.external :as external]
+            [clojure.java.io :as io])
+  (:import (com.apicatalog.jsonld JsonLd JsonLdError JsonLdErrorCode)
            (com.apicatalog.jsonld.document JsonDocument)
+           (com.apicatalog.jsonld.loader DocumentLoader FileLoader DocumentLoaderOptions)
            (com.apicatalog.rdf RdfNQuad)
            (io.setl.rdf.normalization RdfNormalize)
+           (java.net URI)
            (java.io StringReader)))
 
 (set! *warn-on-reflection* true)
@@ -46,18 +50,39 @@
       (StringReader.)
       (JsonDocument/of)))
 
+(defrecord StaticLoader []
+  DocumentLoader
+  (loadDocument [_ url options]
+    (if-let [{path :source} (external/context->file (.toString url))]
+      (-> (FileLoader.)
+          (.loadDocument (URI. (str "file://" (.getAbsolutePath (io/file "")) "/resources/" path))
+                         (DocumentLoaderOptions.)))
+      (throw (JsonLdError. JsonLdErrorCode/LOADING_REMOTE_CONTEXT_FAILED
+                           (str "Unable to load static context: " (.toString url)))))))
+
 (defn expand
   [json-ld]
-  (parsed (.get (JsonLd/expand (->json-document json-ld)))))
+  (-> (->json-document json-ld)
+      (JsonLd/expand)
+      (.loader ^DocumentLoader (->StaticLoader))
+      (.get)
+      (parsed)))
 
 (defn compact
   [json-ld context]
-  (parsed (.get (JsonLd/compact (->json-document json-ld)
-                                (->json-document context)))))
+  (-> (->json-document json-ld)
+      (JsonLd/compact (->json-document context))
+      (.loader ^DocumentLoader (->StaticLoader))
+      (.get)
+      (parsed)))
 
 (defn flatten
   [json-ld]
-  (parsed (.get (JsonLd/flatten (->json-document json-ld)))))
+  (-> (->json-document json-ld)
+      (JsonLd/flatten)
+      (.loader ^DocumentLoader (->StaticLoader))
+      (.get)
+      (parsed)))
 
 (defn- ->statement
   [^RdfNQuad quad]
@@ -90,8 +115,12 @@
 
 (defn to-rdf
   [json-ld]
-  (->> (.toList (.get (JsonLd/toRdf (->json-document json-ld))))
-       (reduce (fn [doc quad] (str doc (->statement quad) "\n")) "")))
+  (-> (->json-document json-ld)
+      (JsonLd/toRdf)
+      (.loader ^DocumentLoader (->StaticLoader))
+      (.get)
+      (.toList)
+      (->> (reduce (fn [doc quad] (str doc (->statement quad) "\n")) ""))))
 
 (defn canonize
   [json-ld]

--- a/src/fluree/json_ld/processor/api.cljs
+++ b/src/fluree/json_ld/processor/api.cljs
@@ -1,33 +1,45 @@
 (ns fluree.json-ld.processor.api
   (:refer-clojure :exclude [flatten])
-  (:require ["jsonld" :as jldjs]))
+  (:require ["jsonld" :as jldjs]
+            [fluree.json-ld.impl.external :as external]))
 
 (defn compact
   [json-ld context]
   (-> json-ld
       (clj->js)
-      (jldjs/compact (clj->js context))
+      (jldjs/compact (clj->js context) #js{"contextUrl" nil, "document" context, "documentUrl" url})
       (.then (fn [result] (js->clj result)))))
+
+(defn static-loader
+  [url options]
+  (js/Promise.
+    (fn [resolve reject]
+      (if-let [context (get external/inlined-contexts url)]
+        (resolve #js{"contextUrl" nil, "document" context, "documentUrl" url})
+        (reject (throw #js{"name" "jsonld.LoadDocumentError"
+                           "message" (str "Unable to load static context: " url)
+                           "details" {"code" "loading remote context failed"
+                                      "url" url}}))))))
 
 (defn expand
   [json-ld]
   (-> json-ld
       (clj->js)
-      (jldjs/expand)
+      (jldjs/expand #js{"documentLoader" static-loader})
       (.then (fn [result] (js->clj result)))))
 
 (defn flatten
   [json-ld]
   (-> json-ld
       (clj->js)
-      (jldjs/flatten)
+      (jldjs/flatten #js{"contextUrl" nil, "document" context, "documentUrl" url})
       (.then (fn [result] (js->clj result)))))
 
 (defn from-rdf
   [n-quads]
   (-> n-quads
       (clj->js)
-      (jldjs/fromRDF #js{"format" "application/n-quads"})
+      (jldjs/fromRDF #js{"format" "application/n-quads"} #js{"contextUrl" nil, "document" context, "documentUrl" url})
       (.then (fn [result] (js->clj result)))))
 
 (defn to-rdf

--- a/test/fluree/json_ld/processor/api_test.clj
+++ b/test/fluree/json_ld/processor/api_test.clj
@@ -1,6 +1,6 @@
 (ns fluree.json-ld.processor.api-test
   (:require [fluree.json-ld.processor.api :as jld-processor]
-            [clojure.test :as t :refer [deftest is]]
+            [clojure.test :as t :refer [deftest is testing]]
             [clojure.string :as str]))
 
 (def context {"@version" 1.1,
@@ -8,12 +8,12 @@
               "alias"    "fluree:alias",
               "cool"     {"@id" "fluree:cool" "@type" "xsd:boolean"}
               "data"     {"@id" "fluree:data", "@type" "@id"},
-              "flakes"   {"@id" "fluree:flakes", "@type" "xsd:long"},
+              "DB"       "fluree:DB",
               "fluree"   "https://ns.flur.ee/ledger#",
               "id"       "@id",
-              "size"     {"@id" "fluree:size", "@type" "xsd:long"},
               "t"        {"@id" "fluree:t", "@type" "xsd:long"},
-              "type"     "@type"})
+              "type"     "@type"
+              "xsd"      "http://www.w3.org/2001/XMLSchema#",})
 
 (def commit
   {"@context" context
@@ -22,32 +22,37 @@
    "data"     {"id"      "fluree:db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
                "type"    "DB",
                "t"       1,
-               "cool"    true
-               "address" "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569",
-               "flakes"  55,
-               "size"    5057}})
+               "cool"    true}})
+
+(def expanded
+  [{"https://ns.flur.ee/ledger#address" [{"@value" ""}],
+    "https://ns.flur.ee/ledger#alias" [{"@value" "test/db19", "@language" "en"}],
+    "https://ns.flur.ee/ledger#data"
+    [{"@id" "https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
+      "@type" ["https://ns.flur.ee/ledger#DB"],
+      "https://ns.flur.ee/ledger#t" [{"@value" 1, "@type" "http://www.w3.org/2001/XMLSchema#long"}],
+      "https://ns.flur.ee/ledger#cool" [{"@value" true, "@type" "http://www.w3.org/2001/XMLSchema#boolean"}]}]}])
+
+
 
 (deftest expansion
-  (let [result (jld-processor/expand commit)]
-    (is (= [{"https://ns.flur.ee/ledger#address" [{"@value" ""}],
-             "https://ns.flur.ee/ledger#alias"
-             [{"@language" "en", "@value" "test/db19"}],
-             "https://ns.flur.ee/ledger#data"
-             [{"https://ns.flur.ee/ledger#address"
-               [{"@value"
-                 "fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569"}],
-               "https://ns.flur.ee/ledger#cool"
-               [{"@type" "xsd:boolean", "@value" true}],
-               "https://ns.flur.ee/ledger#flakes"
-               [{"@type" "xsd:long", "@value" 55}],
-               "@id"
-               "https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6",
-               "https://ns.flur.ee/ledger#size"
-               [{"@type" "xsd:long", "@value" 5057}],
-               "https://ns.flur.ee/ledger#t"
-               [{"@type" "xsd:long", "@value" 1}],
-               "@type" ["DB"]}]}]
-           result))))
+  (testing "inline context"
+    (let [result (jld-processor/expand commit)]
+      (is (= expanded
+             result))))
+
+  (testing "remote context"
+    (let [result (jld-processor/expand (assoc commit "@context"
+                                              [ "https://ns.flur.ee/ledger/v1"
+                                               {"cool" {"@id" "fluree:cool" "@type" "xsd:boolean"}}]))]
+      (is (= expanded
+             result))))
+
+  (testing "remote context failure"
+    (is (= "Unable to load static context: http://failure.foo"
+           (try (jld-processor/expand (assoc commit "@context" "http://failure.foo"))
+                (catch Exception e
+                  (:cause (Throwable->map e))))))))
 
 (deftest compaction
   (let [result (jld-processor/compact (jld-processor/expand commit) context)]
@@ -55,11 +60,9 @@
 
 (deftest to-rdf
   (let [result (sort (str/split-lines (jld-processor/to-rdf commit)))]
-    (is (= ["<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#address> \"fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569\" ."
-            "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#cool> \"true\"^^<xsd:boolean> ."
-            "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#flakes> \"55\"^^<xsd:long> ."
-            "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#size> \"5057\"^^<xsd:long> ."
-            "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#t> \"1\"^^<xsd:long> ."
+    (is (= ["<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ns.flur.ee/ledger#DB> ."
+            "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#cool> \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> ."
+            "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#t> \"1\"^^<http://www.w3.org/2001/XMLSchema#long> ."
             "_:b0 <https://ns.flur.ee/ledger#address> \"\" ."
             "_:b0 <https://ns.flur.ee/ledger#alias> \"test/db19\"@en ."
             "_:b0 <https://ns.flur.ee/ledger#data> <https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> ."]
@@ -91,5 +94,5 @@
 
 (deftest canonize
   (let [result (jld-processor/canonize commit)]
-    (is (= "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#address> \"fluree:memory://e2c8cf4429d7fcd6382fe2c890cf4c3fa2d8d0039b1981ff27e1ee2a05848569\" .\n<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#cool> \"true\"^^<xsd:boolean> .\n<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#flakes> \"55\"^^<xsd:long> .\n<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#size> \"5057\"^^<xsd:long> .\n<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#t> \"1\"^^<xsd:long> .\n_:c14n0 <https://ns.flur.ee/ledger#address> \"\" .\n_:c14n0 <https://ns.flur.ee/ledger#alias> \"test/db19\"@en .\n_:c14n0 <https://ns.flur.ee/ledger#data> <https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> .\n"
+    (is (= "<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://ns.flur.ee/ledger#DB> .\n<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#cool> \"true\"^^<http://www.w3.org/2001/XMLSchema#boolean> .\n<https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> <https://ns.flur.ee/ledger#t> \"1\"^^<http://www.w3.org/2001/XMLSchema#long> .\n_:c14n0 <https://ns.flur.ee/ledger#address> \"\" .\n_:c14n0 <https://ns.flur.ee/ledger#alias> \"test/db19\"@en .\n_:c14n0 <https://ns.flur.ee/ledger#data> <https://ns.flur.ee/ledger#db:sha256:bb3u2hayr4pdwunsa5ijdp7txqrmmku5zlhj7dpozetdcr5g7r5n6> .\n"
            result))))


### PR DESCRIPTION
This hardcodes our static default contexts to the json-ld processor api.

This makes the js package bigger, but the eventual goal is to move all of the default contexts and vocabs out of this library entirely (but that will be a future pr).

I'm not sure how I feel about the different apis for js and jvm - js returns promises, jvm is synchronous. Maybe I'll wrap them with core.async so it's a uniform api? Feedback welcome.