### PR TITLE
Fix compile warnings, add static loader to from-rdf, flatten

### DIFF
--- a/src/fluree/json_ld/processor/api.cljs
+++ b/src/fluree/json_ld/processor/api.cljs
@@ -3,13 +3,6 @@
   (:require ["jsonld" :as jldjs]
             [fluree.json-ld.impl.external :as external]))
 
-(defn compact
-  [json-ld context]
-  (-> json-ld
-      (clj->js)
-      (jldjs/compact (clj->js context) #js{"contextUrl" nil, "document" context, "documentUrl" url})
-      (.then (fn [result] (js->clj result)))))
-
 (defn static-loader
   [url options]
   (js/Promise.
@@ -20,6 +13,13 @@
                            "message" (str "Unable to load static context: " url)
                            "details" {"code" "loading remote context failed"
                                       "url" url}}))))))
+
+(defn compact
+  [json-ld context]
+  (-> json-ld
+      (clj->js)
+      (jldjs/compact (clj->js context) #js{"documentLoader" static-loader})
+      (.then (fn [result] (js->clj result)))))
 
 (defn expand
   [json-ld]
@@ -32,14 +32,14 @@
   [json-ld]
   (-> json-ld
       (clj->js)
-      (jldjs/flatten #js{"contextUrl" nil, "document" context, "documentUrl" url})
+      (jldjs/flatten #js{"documentLoader" static-loader})
       (.then (fn [result] (js->clj result)))))
 
 (defn from-rdf
   [n-quads]
   (-> n-quads
       (clj->js)
-      (jldjs/fromRDF #js{"format" "application/n-quads"} #js{"contextUrl" nil, "document" context, "documentUrl" url})
+      (jldjs/fromRDF #js{"format" "application/n-quads" "documentLoader" static-loader})
       (.then (fn [result] (js->clj result)))))
 
 (defn to-rdf


### PR DESCRIPTION
The old options were undefined, this changes the options to just use the static loader.