### PR TITLE
expand with static loader before canonization

### DIFF
--- a/src/fluree/json_ld/processor/api.cljs
+++ b/src/fluree/json_ld/processor/api.cljs
@@ -46,7 +46,8 @@
   [json-ld]
   (-> json-ld
       (clj->js)
-      (jldjs/toRDF #js{"format" "application/n-quads"})))
+      (jldjs/expand #js{"documentLoader" static-loader})
+      (.then (fn [expanded] (jldjs/toRDF expanded #js{"format" "application/n-quads"})))))
 
 (defn canonize
   [json-ld]

--- a/test/fluree/json_ld/processor/api_test.cljs
+++ b/test/fluree/json_ld/processor/api_test.cljs
@@ -73,6 +73,15 @@
                              result))
                       (done))))))
 
+(deftest to-rdf--remote-context
+  (async done
+         (-> (jld-processor/to-rdf {"@context" "https://ns.flur.ee/ledger/v1"
+                                    "address" ""})
+             (.then (fn [result]
+                      (is (= "_:b0 <https://ns.flur.ee/ledger#address> \"\" .\n"
+                             result))
+                      (done))))))
+
 (deftest from-rdf
   (async done
          (-> (jld-processor/to-rdf commit)
@@ -105,6 +114,14 @@
                              result))
                       (done))))))
 
+(deftest canonize--remote-context
+  (async done
+         (-> (jld-processor/canonize {"@context" "https://ns.flur.ee/ledger/v1"
+                                      "address" ""})
+             (.then (fn [result]
+                      (is (= "_:c14n0 <https://ns.flur.ee/ledger#address> \"\" .\n"
+                             result))
+                      (done))))))
 
 (comment
   (t/run-tests)


### PR DESCRIPTION
json-ld needs to be expanded with our static loader before canonization, otherwise the canonization will throw an error as it tries to parse it into nquads.

This fixes a problem found by https://github.com/fluree/db/issues/333