### PR TITLE
Allow context to be cleared by setting it to nil

### DIFF
--- a/src/fluree/json_ld/impl/context.cljc
+++ b/src/fluree/json_ld/impl/context.cljc
@@ -186,7 +186,7 @@
      (cond
        ;; nil resets the context
        (nil? context)
-       active-context
+       {}
 
        ;; assume either an external context, or a default vocab
        (string? context)

--- a/test/fluree/json_ld/impl/compact_test.cljc
+++ b/test/fluree/json_ld/impl/compact_test.cljc
@@ -18,7 +18,16 @@
       ;; not a match, should return unaltered iri
       (is (= "schemas" (compact/compact "schemas" map-ctx)))
       (is (= "http://example.org/ns#blah" (compact/compact "http://example.org/ns#blah" str-ctx)))
-      (is (= "http://example.org/ns#blah" (compact/compact "http://example.org/ns#blah" map-ctx))))))
+      (is (= "http://example.org/ns#blah" (compact/compact "http://example.org/ns#blah" map-ctx)))))
+
+  (testing "A nil context clears the context"
+    (let [cleared-ctx (jsonld/parse-context [{"schema" "http://schema.org/"
+                                              "REPLACE" "http://schema.org/Person"
+                                              "x" "schema:x"}
+                                             nil])]
+      (is (= "http://schema.org/x" (compact/compact "http://schema.org/x" cleared-ctx)))
+      (is (= "http://schema.org/xyz" (compact/compact "http://schema.org/xyz" cleared-ctx)))
+      (is (= "http://schema.org/Person" (compact/compact "http://schema.org/Person" cleared-ctx))))))
 
 
 (deftest compacting-function

--- a/test/fluree/json_ld/impl/context_test.cljc
+++ b/test/fluree/json_ld/impl/context_test.cljc
@@ -78,26 +78,32 @@
 
 (deftest multiple-contexts
   (testing "Context map parsing"
-    (is (= (context/parse [{"schema" "http://schema.org/"},
-                           {"owl" "http://www.w3.org/2002/07/owl#",
-                            "ex"  "http://example.org/ns#"}])
-           {:type-key "@type"
+    (is (= {:type-key "@type"
             "schema"  {:id "http://schema.org/"}
             "owl"     {:id "http://www.w3.org/2002/07/owl#"}
-            "ex"      {:id "http://example.org/ns#"}})))
+            "ex"      {:id "http://example.org/ns#"}}
+           (context/parse [{"schema" "http://schema.org/"},
+                           {"owl" "http://www.w3.org/2002/07/owl#",
+                            "ex"  "http://example.org/ns#"}]))))
 
   (testing "A second context may rely on definitions in the first"
     ;; this scenario happened with https://w3id.org/security/v1 -> https://w3id.org/security/v2
-    (is (= (context/parse [{"sec" "https://w3id.org/security#"}
-                           {"EcdsaSecp256k1VerificationKey2019" "sec:EcdsaSecp256k1VerificationKey2019"}])
-           {:type-key                           "@type"
+    (is (= {:type-key                           "@type"
             "sec"                               {:id "https://w3id.org/security#"},
-            "EcdsaSecp256k1VerificationKey2019" {:id "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"}})))
+            "EcdsaSecp256k1VerificationKey2019" {:id "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"}}
+           (context/parse [{"sec" "https://w3id.org/security#"}
+                           {"EcdsaSecp256k1VerificationKey2019" "sec:EcdsaSecp256k1VerificationKey2019"}]))))
   (testing "A nil context empties the context"
-    ;; this scenario happened with https://w3id.org/security/v1 -> https://w3id.org/security/v2
-    (is (= (context/parse [{"sec" "https://w3id.org/security#"}
-                           nil])
-           {}))))
+    (let [parsed {:type-key "@type", "sec" {:id "https://w3id.org/security#"}}]
+      (is (= parsed
+            (context/parse {"sec" "https://w3id.org/security#"}))
+          "a parsed context")
+      (is (= parsed
+             (context/parse parsed {}))
+          "an unmodified parsed context")
+      (is (= {}
+             (context/parse parsed nil))
+          "an empty context"))))
 
 
 (deftest nested-context-details

--- a/test/fluree/json_ld/impl/context_test.cljc
+++ b/test/fluree/json_ld/impl/context_test.cljc
@@ -92,7 +92,12 @@
                            {"EcdsaSecp256k1VerificationKey2019" "sec:EcdsaSecp256k1VerificationKey2019"}])
            {:type-key                           "@type"
             "sec"                               {:id "https://w3id.org/security#"},
-            "EcdsaSecp256k1VerificationKey2019" {:id "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"}}))))
+            "EcdsaSecp256k1VerificationKey2019" {:id "https://w3id.org/security#EcdsaSecp256k1VerificationKey2019"}})))
+  (testing "A nil context empties the context"
+    ;; this scenario happened with https://w3id.org/security/v1 -> https://w3id.org/security/v2
+    (is (= (context/parse [{"sec" "https://w3id.org/security#"}
+                           nil])
+           {}))))
 
 
 (deftest nested-context-details

--- a/test/fluree/json_ld/impl/context_test.cljc
+++ b/test/fluree/json_ld/impl/context_test.cljc
@@ -86,7 +86,7 @@
             "owl"     {:id "http://www.w3.org/2002/07/owl#"}
             "ex"      {:id "http://example.org/ns#"}})))
 
-  (testing "An second context may rely on definitions in the first"
+  (testing "A second context may rely on definitions in the first"
     ;; this scenario happened with https://w3id.org/security/v1 -> https://w3id.org/security/v2
     (is (= (context/parse [{"sec" "https://w3id.org/security#"}
                            {"EcdsaSecp256k1VerificationKey2019" "sec:EcdsaSecp256k1VerificationKey2019"}])


### PR DESCRIPTION
This addresses/enables a solution for https://github.com/fluree/db/issues/395

If a context is set to nil, `compact` should return fully expanded json-ld.
