### PR TITLE
Use `type-key` optimization even when node uses`@type` instead

### DIFF
--- a/src/fluree/json_ld/impl/expand.cljc
+++ b/src/fluree/json_ld/impl/expand.cljc
@@ -229,8 +229,10 @@
   and a (possibly) updated context if there was a type-dependent sub-context present.
   Always return @type as a vector regardless of input."
   [node-map context idx]
-  (let [base (if (empty? idx) {:idx []} {:idx idx})]
-    (if-let [type-val (get node-map (:type-key context))]
+  (let [base (if (empty? idx) {:idx []} {:idx idx})
+        {:keys [type-key]} context]
+    (if-let [type-val (or (get node-map type-key)
+                          (get node-map (get-in context [type-key :id])))]
       (let [type-val*     (sequential type-val)
             ;; context may have type-dependent sub-context, update context if so
             context+types (type-sub-context context type-val*)
@@ -321,7 +323,8 @@
          (if-let [graph (get node-map graph-key)]
            (expand-nodes context externals (conj idx "@graph") graph)
            (let [[base-result context*] (parse-type node-map context idx)
-                 node-map* (dissoc node-map "@context" :context (:type-key context))]
+                 {:keys [type-key]} context
+                 node-map* (dissoc node-map "@context" :context (:type-key context) (get-in context [type-key :id]))]
              (node* node-map* base-result externals context*)))))
      (catch e
             (if (ex-data e)

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -53,7 +53,7 @@
                          "@type"    "Movie"
                          "name"     "Hitchhiker's Guide to the Galaxy"})
            {:id   "https://www.wikidata.org/wiki/Q836821"
-            :type "http://schema.org/Movie"
+            :type ["http://schema.org/Movie"]
             "http://schema.org/name"
             {:value "Hitchhiker's Guide to the Galaxy", :type nil, :idx ["name"]}
             :idx  []})))
@@ -439,6 +439,78 @@
             :id "http://example.com/ns#item123",
             "http://example.com/ns#favColor" [{:id "http://example.com/ns#red", :idx [:ex/favColor 0]}
                                               {:id "http://example.com/ns#green", :idx [:ex/favColor 1]}]}))))
+
+(deftest shacl-embedded-nodes
+    (testing "clojure kws"
+      (is (= {:idx [],
+              :type ["http://www.w3.org/ns/shacl#NodeShape"],
+              :id "http://example.org/ns/UserShape",
+              "http://www.w3.org/ns/shacl#targetClass"
+              {:id "http://example.org/ns/User",
+               :idx [:sh/targetClass]},
+              "http://www.w3.org/ns/shacl#property"
+              [{:idx [:sh/property 0],
+                "http://www.w3.org/ns/shacl#path"
+                {:id "http://schema.org/name",
+                 :idx [:sh/property 0 :sh/path]},
+                "http://www.w3.org/ns/shacl#datatype"
+                {:id "http://www.w3.org/2001/XMLSchema#string",
+                 :idx [:sh/property 0 :sh/datatype]}}]}
+
+             (expand/node
+              {:id :ex/UserShape,
+               :type [:sh/NodeShape],
+               :sh/targetClass :ex/User,
+               :sh/property [{:sh/path :schema/name,
+                              :sh/datatype :xsd/string}]}
+
+              {:schema {:id "http://schema.org/"},
+               :wiki {:id "https://www.wikidata.org/wiki/"},
+               :xsd {:id "http://www.w3.org/2001/XMLSchema#"},
+               :type {:id "@type",
+                      :type? true},
+               :rdfs {:id "http://www.w3.org/2000/01/rdf-schema#"},
+               :type-key :type,
+               :ex {:id "http://example.org/ns/"},
+               :id {:id "@id"},
+               :f {:id "https://ns.flur.ee/ledger#"},
+               :sh {:id "http://www.w3.org/ns/shacl#"},
+               :skos {:id "http://www.w3.org/2008/05/skos#"},
+               :rdf {:id "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}})){}))
+    (testing "string, with `:type-key` of 'type', but node uses @type"
+      (is (= {:idx [],
+              :id "http://example.org/ns/UserShape",
+              :type ["http://www.w3.org/ns/shacl#NodeShape"],
+              "http://www.w3.org/ns/shacl#targetClass"
+              {:id "http://example.org/ns/User", :idx ["sh:targetClass"]},
+              "http://www.w3.org/ns/shacl#property"
+              [{:idx ["sh:property" 0],
+                "http://www.w3.org/ns/shacl#datatype"
+                {:id "http://www.w3.org/2001/XMLSchema#string",
+                 :idx ["sh:property" 0 "sh:datatype"]},
+                "http://www.w3.org/ns/shacl#path"
+                {:id "http://schema.org/name", :idx ["sh:property" 0 "sh:path"]}}]}
+
+             (expand/node
+              {"@id" "ex:UserShape",
+               "@type" ["sh:NodeShape"],
+               "sh:targetClass" {"@id" "ex:User"},
+               "sh:property" [{"sh:datatype" {"@id" "xsd:string"},
+                               "sh:path" {"@id" "schema:name"}}]}
+
+              {"f" {:id "https://ns.flur.ee/ledger#"},
+               "rdf" {:id "http://www.w3.org/1999/02/22-rdf-syntax-ns#"},
+               "schema" {:id "http://schema.org/"},
+               "id" {:id "@id"},
+               "wiki" {:id "https://www.wikidata.org/wiki/"},
+               :type-key "type",
+               "ex" {:id "http://example.org/ns/"},
+               "rdfs" {:id "http://www.w3.org/2000/01/rdf-schema#"},
+               "type" {:id "@type",
+                       :type? true},
+               "sh" {:id "http://www.w3.org/ns/shacl#"},
+               "skos" {:id "http://www.w3.org/2008/05/skos#"},
+               "xsd" {:id "http://www.w3.org/2001/XMLSchema#"}})))))
 
 (comment
   (expanding-iri)


### PR DESCRIPTION
(Note: This is some work I did in the course of looking at https://github.com/fluree/http-api-gateway/issues/36, but importantly, is not required. Nothing was broken here as far as I can tell, I just had this lying around and figured I'd see if it was worth merging.)

Our `expand` implementation has an internal optimization in which it looks for a `:type-key` in the context, and uses its value to lift the discovery of a node type to early in the process (see [this comment](https://github.com/fluree/http-api-gateway/issues/36#issuecomment-1458875066)).  This is a key we add internally in `db` [during the commit process](https://github.com/fluree/db/blob/6a7211bcd195cc718eb6eb9e415111013a39edaf/src/fluree/db/json_ld/commit.cljc#L209). The `:type-key` is always compacted.

This PR extends this optimization to look for the expanded form as well.  This way, even if the context maps eg `{"type" : "@type"}` (and the `:type-key` is therefore `"type"`), if the node uses the expanded `"@type"` instead, the optimization will still apply.

I also added a test which both exercises this and illustrates expanding SHACL shapes, as a 2-for-1 😄. This test illustrates that with strings, you have to explicitly provide the `@id` for node values that are iris to create a ref (see [this comment](https://github.com/fluree/http-api-gateway/issues/36#issuecomment-1460282463)). AFAICT there wasn't previously a test of expanding a node which embeds another node, so I thought it'd be good to include.