### PR TITLE
Add un-parse API for context

### DIFF
--- a/src/fluree/json_ld.cljc
+++ b/src/fluree/json_ld.cljc
@@ -22,6 +22,12 @@
   ([base-context externals context]
    (context/parse base-context externals context)))
 
+(defn un-parse-context 
+  "Takes a parsed context and returns it to a standard json-ld context
+  in the most compact form it can."
+  [parsed-context]
+  (context/un-parse parsed-context))
+
 
 (defn external-vocab
   "Loads a supported external vocabulary for a specific iri, which should be

--- a/test/fluree/json_ld/impl/context_test.cljc
+++ b/test/fluree/json_ld/impl/context_test.cljc
@@ -1,5 +1,5 @@
 (ns fluree.json-ld.impl.context-test
-  (:require #?(:clj [clojure.test :as t :refer [deftest testing is]]
+  (:require #?(:clj  [clojure.test :as t :refer [deftest testing is]]
                :cljs [cljs.test :as t :refer [deftest testing is] :include-macros true])
             [fluree.json-ld.impl.context :as context]))
 
@@ -200,3 +200,19 @@
             :id       {:id "@id"}
             :type     {:id "@type", :type? true}
             :schema   {:id "http://schema.org/"}}))))
+
+(deftest un-parsing-context
+  (testing "A simple context parsed returns to its original form when unparsed"
+    (let [sample-ctx {"schema"     "http://schema.org"
+                      "ex"         "http://example.org/"
+                      "xsd"        "http://xsd/"
+                      "ex:favNumb" {"@type" "xsd:integer"}
+                      "ex:friend"  {"@type" "@id"}
+                      "blah"       {"@type" "xsd:hello"
+                                    "@id"   "http://flur.ee/wow"}
+                      "id"         "@id"
+                      "type"       "@type"}
+          parsed (context/parse sample-ctx)
+          un-parsed (context/un-parse parsed)]
+      (is (= sample-ctx
+             un-parsed)))))


### PR DESCRIPTION
This adds a new `un-parse-context` API which allows you to take a parsed context and turn it back into its likely original form.

While the functionality if the un-parsed context will be identical to the original, that it is the exact same as the original is not guaranteed. But it should be in most circumstances.
