### PR TITLE
Fix composition of relative @vocab w/ @base

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,10 +24,9 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps  {com.cognitect/test-runner
-                 {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                  :sha     "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
-   :exec-fn     cognitect.test-runner.api/test}
+   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.85.1342"}}
+   :exec-fn     kaocha.runner/exec-fn
+   :exec-args   {}}
 
   :js-deps
   {:extra-deps {com.timetraveltoaster/target-bundle-libs {:mvn/version "RELEASE"}}

--- a/src/fluree/json_ld/impl/context.cljc
+++ b/src/fluree/json_ld/impl/context.cljc
@@ -2,8 +2,7 @@
   (:require [fluree.json-ld.impl.iri :as iri]
             [fluree.json-ld.impl.util :refer [try-catchall]]
             [fluree.json-ld.impl.external :as external]
-            [clojure.string :as str])
-  (:import (java.net URI)))
+            [clojure.string :as str]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -24,12 +23,10 @@
                  (get base-context :base))]
     (if (= "" vocab) ; empty string means use @base as @vocab
       (when base (iri/add-trailing-slash base))
-      (let [vocab-uri (URI/create vocab)]
-        (if (and base (-> vocab-uri .isAbsolute not)) ; @vocab relative to @base
-          (->> vocab-uri
-               (.resolve (URI/create base))
-               .toString)
-          (iri/add-trailing-slash vocab))))))
+      (if (and base (not (iri/absolute? vocab)))
+        ;; @vocab relative to @base
+        (iri/join base vocab)
+        (iri/add-trailing-slash vocab)))))
 
 (defn parse-compact-iri-val
   "A context's value may itself be a compact IRI which refers to

--- a/src/fluree/json_ld/impl/context.cljc
+++ b/src/fluree/json_ld/impl/context.cljc
@@ -167,7 +167,6 @@
                   (keywordize-at-value v)
 
                   :else v)]
-         (println "assoc k:" kw "v:" v*)
          (assoc acc kw v*))
        (let [parsed-v (parse-value k v context base-context externals)]
          (cond-> (assoc acc k parsed-v)

--- a/src/fluree/json_ld/impl/expand.cljc
+++ b/src/fluree/json_ld/impl/expand.cljc
@@ -6,7 +6,6 @@
 
 ;; TODO - differentiate resolution between @type: @id vs @type: @vocab
 ;; TODO - support @container: @language indexed value
-;; TODO - support for @base - applies only to values, not @type or properties (or where explicit @type: @vocab used)
 
 #?(:clj (set! *warn-on-reflection* true))
 

--- a/src/fluree/json_ld/impl/iri.cljc
+++ b/src/fluree/json_ld/impl/iri.cljc
@@ -1,6 +1,7 @@
 (ns fluree.json-ld.impl.iri
   (:require [fluree.json-ld.impl.util :refer [try-catchall]]
-            [clojure.string :as str]))
+            [clojure.string :as str])
+  #?(:clj (:import (java.net URI))))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -45,3 +46,16 @@
                              {:status 400
                               :error  :json-ld/invalid-iri}
                              e)))))
+
+(defn join
+  "Returns an IRI string for string s relative to base IRI."
+  [base ^String s]
+  #?(:clj  (->> s (.resolve (URI/create base)) .toString)
+     :cljs (-> s (js/URL. base) .toString)))
+
+(defn absolute?
+  "Returns true if given IRI is absolute, false otherwise.
+  NB: A false return value does NOT imply that it is a valid relative IRI."
+  [iri]
+  #?(:clj  (try (-> iri URI/create .isAbsolute) (catch Exception _ false))
+     :cljs (boolean (try (js/URL. iri) (catch :default _ false)))))

--- a/src/fluree/json_ld/impl/iri.cljc
+++ b/src/fluree/json_ld/impl/iri.cljc
@@ -1,7 +1,6 @@
 (ns fluree.json-ld.impl.iri
   (:require [fluree.json-ld.impl.util :refer [try-catchall]]
-            [clojure.string :as str])
-  #?(:clj (:import (java.net URI))))
+            [clojure.string :as str]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -48,14 +47,14 @@
                              e)))))
 
 (defn join
-  "Returns an IRI string for string s relative to base IRI."
-  [base ^String s]
-  #?(:clj  (->> s (.resolve (URI/create base)) .toString)
-     :cljs (-> s (js/URL. base) .toString)))
+  "Returns an IRI string for relative IRI `ri` relative to absolute `base` IRI.
+  Makes no attempt to correct trailing / leading character errors, so make sure
+  `base` ends in / or # and `ri` begins with neither."
+  [base ri]
+  (str base ri))
 
 (defn absolute?
-  "Returns true if given IRI is absolute, false otherwise.
-  NB: A false return value does NOT imply that it is a valid relative IRI."
+  "A very basic check if an IRI is absolute. NB: A false result does not imply
+  that it is a valid relative IRI."
   [iri]
-  #?(:clj  (try (-> iri URI/create .isAbsolute) (catch Exception _ false))
-     :cljs (boolean (try (js/URL. iri) (catch :default _ false)))))
+  (str/includes? iri ":"))

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -336,7 +336,7 @@
                          "nick" ["joe", "bob", "jaybee"]})))))
 
 
-(deftest base-and-vocab
+(deftest base-and-vocab-test
   (testing "An @base and a @vocab expand the correct iris"
     (is (= {:id   "https://base.com/base/iri#joebob"
             :idx  []
@@ -352,7 +352,6 @@
                          "@id"         "#joebob",
                          "@type"       "Joey"
                          "name"        "Joe Bob"
-                         "iriProperty" "#a-relative-id"})))))
                          "iriProperty" "#a-relative-id"}))))
   (testing "A absolute @base and a relative @vocab expand the correct iris"
     (let [context* {"@base"       "http://example.com/"

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -353,6 +353,24 @@
                          "@type"       "Joey"
                          "name"        "Joe Bob"
                          "iriProperty" "#a-relative-id"})))))
+                         "iriProperty" "#a-relative-id"}))))
+  (testing "A absolute @base and a relative @vocab expand the correct iris"
+    (let [context* {"@base"       "http://example.com/"
+                    "@vocab"      "ns/"
+                    "iriProperty" {"@type" "@id"}}
+          data     {"@id"         "#joebob"
+                    "@type"       "Joey"
+                    "name"        "Joe Bob"
+                    "iriProperty" "#a-relative-id"}]
+      (is (= {:idx                                []
+              :type                               ["http://example.com/ns/Joey"]
+              :id                                 "http://example.com/#joebob"
+              "http://example.com/ns/name"        {:value "Joe Bob"
+                                                   :type  nil
+                                                   :idx   ["name"]}
+              "http://example.com/ns/iriProperty" {:id  "http://example.com/#a-relative-id"
+                                                   :idx ["iriProperty"]}}
+             (expand/node (assoc data "@context" context*)))))))
 
 (deftest type-sub-context
   (testing "When @context has a sub-@context for specific types, ensure merged"


### PR DESCRIPTION
Closes #20 

~~This uses the `java.net.URI` class to determine if @vocab is relative and to resolve it in terms of @base when it is. There are enough wrinkles and corner cases there that it seemed appropriate (and worth the potential performance hit) to use that API rather than just doing simple string inclusion checks and concatenation. But let me know if that seems wrong.~~
UPDATE: It uses a much simpler approach now that should also be more compatible with the larger character set that IRIs use vs. URIs.

This also switches the test runner to kaocha for consistency and to get the nicer data structure diff output on failure.