### PR TITLE
allow normalization of maps that have symbol keys

### DIFF
--- a/src/fluree/json_ld/impl/normalize.cljc
+++ b/src/fluree/json_ld/impl/normalize.cljc
@@ -53,7 +53,7 @@
 
 (defmethod basic-normalize :map
   [node]
-  (let [sorted    (sort-by first (into [] node))
+  (let [sorted    (sort-by #(-> % first str) (into [] node))
         ser-nodes (mapv (fn [[k v]]
                           (str "\"" k "\":" (basic-normalize v)))
                         sorted)]

--- a/test/fluree/json_ld/impl/normalize_test.cljc
+++ b/test/fluree/json_ld/impl/normalize_test.cljc
@@ -39,6 +39,11 @@
       (is (= "{\"literals\":[null,true,false],\"numbers\":[333333333.3333333,1e+30,4.5,0.002,1e-27]}"
              (normalize/normalize data {:algorithm :basic
                               :format    :application/json})))))
+  (testing "Symbol keys"
+    (let [data {"id" '?s '?p '?o}]
+      (is (= "{\"?p\":?o,\"id\":?s}"
+             (normalize/normalize data {:algorithm :basic
+                                        :format :application/json})))))
 
   ;; Note below fails but should not. Most unicode control set characters (< \u000f) should remain as is
   ;; but with lower case hex. Below, \u000F gets parsed but should instead output \u000f


### PR DESCRIPTION
We now allow symbols within transactions as variables. In order to normalize, we sort the map entries by key. You cannot compare a symbol and a string, so this fails with symbol variables.

This PR allows for the normalization of data with symbols.