### PR TITLE
Support colon prefix

### DIFF
--- a/src/fluree/json_ld/impl/expand.cljc
+++ b/src/fluree/json_ld/impl/expand.cljc
@@ -390,20 +390,3 @@
                               {:status 400
                                :error  :json-ld/invalid}
                               e)))))))
-
-
-(comment
-
-  (node {"@context"                  "https://schema.org",
-         "@id"                       "https://www.wikidata.org/wiki/Q836821",
-         "@type"                     "Movie",
-         "name"                      "HELLO The Hitchhiker's Guide to the Galaxy",
-         "disambiguatingDescription" "2005 British-American comic science fiction film directed by Garth Jennings",
-         "titleEIDR"                 "10.5240/B752-5B47-DBBE-E5D4-5A3F-N",
-         "isBasedOn"                 {"@id"    "https://www.wikidata.org/wiki/Q3107329",
-                                      "@type"  "Book",
-                                      "name"   "The Hitchhiker's Guide to the Galaxy",
-                                      "isbn"   "0-330-25864-8",
-                                      "author" {"@id"   "https://www.wikidata.org/wiki/Q42"
-                                                "@type" "Person"
-                                                "name"  "Douglas Adams"}}}))

--- a/src/fluree/json_ld/impl/iri.cljc
+++ b/src/fluree/json_ld/impl/iri.cljc
@@ -13,8 +13,9 @@
   [x]
   (if (keyword? x)
     [x (keyword (namespace x)) (name x)]
-    (re-matches #"([^:/]+):([^/:][^:]*)" x)))
-
+    (if (= \: (first x))
+      [x ":" (subs x 1)] ;; prefix is ':'
+      (re-matches #"([^:/]+):([^/:][^:]*)" x))))
 
 (defn any-iri?
   "Returns true if string has a colon, indicating it is either a compact

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -641,6 +641,22 @@
            (expand/node {"@id" "foo"
                          "bar" {"@value" false}})))))
 
+(deftest empty-colon-test
+  (testing "Testing context key of ':' expands properly."
+    (is (= {"http://somedomain.org/age"     [{:idx   [":age"]
+                                              :type  nil
+                                              :value 33}]
+            "http://example.com/vocab/name" [{:idx   ["ex:name"]
+                                              :type  nil
+                                              :value "Frank"}]
+            :idx                            []}
+           (expand/node {"@context"
+                         {"ex" "http://example.com/vocab/"
+                          ":"  "http://somedomain.org/"}
+                         "ex:name" "Frank"
+                         ":age"    33})))))
+
+
 (comment
   (expanding-iri)
   (expanding-reverse-iri)

--- a/test/fluree/json_ld/impl/iri_test.cljc
+++ b/test/fluree/json_ld/impl/iri_test.cljc
@@ -6,23 +6,29 @@
 (deftest prefix-parsing
   (testing "Prefix parsing returns prefix and suffix correctly"
 
-    (is (= (iri/parse-prefix "schema:name") ["schema" "name"]))
+    (is (= ["schema" "name"]
+           (iri/parse-prefix "schema:name")))
 
-    (is (= (iri/parse-prefix "fluree:some/namespace") ["fluree" "some/namespace"]))
+    (is (= ["fluree" "some/namespace"]
+           (iri/parse-prefix "fluree:some/namespace")))
 
-    (is (= (iri/parse-prefix "ex:a") ["ex" "a"]))
+    (is (= ["ex" "a"]
+           (iri/parse-prefix "ex:a")))
 
-    (is (= (iri/parse-prefix "a:b") ["a" "b"]))
+    (is (= ["a" "b"]
+           (iri/parse-prefix "a:b")))
+
+    (is (= [":" "schema:name"]
+           (iri/parse-prefix ":schema:name")))
+
+    (is (= [":" "schema"]
+           (iri/parse-prefix ":schema")))
 
     (is (nil? (iri/parse-prefix "fluree/some:namespace")))
 
     (is (nil? (iri/parse-prefix "fluree/cool")))
 
     (is (nil? (iri/parse-prefix "schema::name")))
-
-    (is (= (iri/parse-prefix ":schema:name") [":" "schema:name"]))
-
-    (is (= (iri/parse-prefix ":schema") [":" "schema"]))
 
     (is (nil? (iri/parse-prefix "schema:")))
 

--- a/test/fluree/json_ld/impl/iri_test.cljc
+++ b/test/fluree/json_ld/impl/iri_test.cljc
@@ -20,9 +20,9 @@
 
     (is (nil? (iri/parse-prefix "schema::name")))
 
-    (is (nil? (iri/parse-prefix ":schema:name")))
+    (is (= (iri/parse-prefix ":schema:name") [":" "schema:name"]))
 
-    (is (nil? (iri/parse-prefix ":schema")))
+    (is (= (iri/parse-prefix ":schema") [":" "schema"]))
 
     (is (nil? (iri/parse-prefix "schema:")))
 


### PR DESCRIPTION
This adds supports for the single colon `:` prefix.

This is commonly used in examples, in particular TTL files in the wild.
