### PR TITLE
Prevent variable expansion

### DIFF
--- a/src/fluree/json_ld/impl/expand.cljc
+++ b/src/fluree/json_ld/impl/expand.cljc
@@ -11,6 +11,11 @@
 
 (declare node)
 
+(defn variable?
+  [x]
+  (and (or (string? x) (symbol? x) (keyword? x))
+       (-> x name first (= \?))))
+
 (defn match-exact
   "Attempts to do an exact match with a compact-iri.
   If successful returns two-tuple of [full-iri context-map-details].
@@ -41,13 +46,15 @@
   If successful returns two-tuple of [full-iri context-map-details].
   Else returns nil."
   [compact-iri context vocab?]
-  (when-let [default-match (if vocab?
-                             (:vocab context)
-                             (:base context))]
-    (when-not (or (iri/any-iri? compact-iri)
-                  (= \@ (first compact-iri)))
-      (let [iri (str default-match compact-iri)]
-        [iri {:id iri}]))))
+  (if (variable? compact-iri)
+    [compact-iri {}]
+    (when-let [default-match (if vocab?
+                               (:vocab context)
+                               (:base context))]
+      (when-not (or (iri/any-iri? compact-iri)
+                    (= \@ (first compact-iri)))
+        (let [iri (str default-match compact-iri)]
+          [iri {:id iri}])))))
 
 
 (defn details

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -656,6 +656,20 @@
                          "ex:name" "Frank"
                          ":age"    33})))))
 
+(deftest variables
+  (testing "vars are not expanded by base/vocab"
+    (is (= {:idx [],
+            "https:example.com/ns/foo"
+            [{:idx ["foo"],
+              :id "?s",
+              "?p" [{:value "?o", :type nil, :idx ["foo" "?p"]}]}],
+            "https:example.com/ns/bar"
+            [{:idx ["bar"],
+              :id "https:example.com/me",
+              "https:example.com/ns/name" [{:value "Dan", :type nil, :idx ["bar" "name"]}]}]}
+           (expand/node {"@context" {"@base" "https:example.com/" "@vocab" "ns/"}
+                         "foo" {"@id" "?s" "?p" "?o"}
+                         "bar" {"@id" "me" "name" "Dan"}})))))
 
 (comment
   (expanding-iri)


### PR DESCRIPTION
When variables were passed in with a context that specifies an @base or an @vocab, the variables were being expanded. JSON-LD does not know about our variable syntax and this commit provides an exception for keywords, symbols, and strings that start with a question mark.

Fixes https://github.com/fluree/core/issues/53