### PR TITLE
Expand Named Graphs

### DIFF
--- a/src/fluree/json_ld/impl/expand.cljc
+++ b/src/fluree/json_ld/impl/expand.cljc
@@ -350,18 +350,14 @@
       (persistent! acc))))
 
 
-(defn- expand-nodes
-  "Expands a sequence of graph nodes (json objects), ensures any nil nodes removed."
+(defn expand-nodes
   [context externals idx nodes]
-  (loop [[json-node & r] nodes
-         i   0
-         acc []]
-    (if json-node
-      (recur r (inc i)
-             (conj acc (node json-node context externals (conj idx i))))
-      (if (empty? r)
-        acc
-        (recur r (inc i) acc)))))
+  (into []
+        (comp (map-indexed (fn [i jsonld]
+                             (when jsonld
+                               (expand-node jsonld context externals (conj idx i)))))
+              (remove nil?))
+        nodes))
 
 
 (defn node

--- a/src/fluree/json_ld/impl/expand.cljc
+++ b/src/fluree/json_ld/impl/expand.cljc
@@ -240,20 +240,21 @@
 (defmethod parse-node-val :sequential
   [v v-info context externals idx]
   (let [v* (into []
-                 (comp (map-indexed #(cond
-                                       (map? %2) (if (or (contains? %2 "@value")
-                                                         (contains? %2 :value))
-                                                   (parse-node-val %2 v-info context externals (conj idx %1))
-                                                   [(expand-node %2 context externals (conj idx %1))])
+                 (comp (map-indexed (fn [i item]
+                                      (cond
+                                        (map? item) (if (or (contains? item "@value")
+                                                          (contains? item :value))
+                                                    (parse-node-val item v-info context externals (conj idx i))
+                                                    [(expand-node item context externals (conj idx i))])
 
-                                       (sequential? %2) (throw (ex-info (str "Json-ld sequential values within sequential"
-                                                                             "values is not allowed. Provided value: " v
-                                                                             " at index: " (conj idx %1) ".")
-                                                                        {:status 400
-                                                                         :error  :json-ld/invalid-context
-                                                                         :idx    (conj idx %1)}))
-                                       :else
-                                       (parse-node-val %2 v-info context externals (conj idx %1))))
+                                        (sequential? item) (throw (ex-info (str "Json-ld sequential values within sequential"
+                                                                              "values is not allowed. Provided value: " v
+                                                                              " at index: " (conj idx i) ".")
+                                                                         {:status 400
+                                                                          :error  :json-ld/invalid-context
+                                                                          :idx    (conj idx i)}))
+                                        :else
+                                        (parse-node-val item v-info context externals (conj idx i)))))
                        cat)
                  v)]
     (if (= :list (:container v-info))

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -285,7 +285,8 @@
                                              {"@id"              "http://example.org/library/the-republic#introduction",
                                               "@type"            "ex:Chapter",
                                               "dc11:description" "An introductory chapter on The Republic.",
-                                              "dc11:title"       "The Introduction"}]})))))
+                                              "dc11:title"       "The Introduction"}]})))
+          "expands the graph as a sequence"))
     (testing "with a top level named graph"
       (is (= {:graph [{"http://example.org/vocab#contains" [{:id "http://example.org/library/the-republic",
                                                              :idx ["@graph" 0 "ex:contains"]}],
@@ -330,7 +331,8 @@
                                        {"@id"              "http://example.org/library/the-republic#introduction",
                                         "@type"            "ex:Chapter",
                                         "dc11:description" "An introductory chapter on The Republic.",
-                                        "dc11:title"       "The Introduction"}]}))))))
+                                        "dc11:title"       "The Introduction"}]}))
+          "retains the named graph's properties"))))
 
 
 (deftest list-type-values

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -243,48 +243,94 @@
                                          {"step" 5, "description" "Garnish with a lime wedge."}]})))))
 
 (deftest node-graph-parse
-  (testing "Parse node that is a graph"
-    (is (= [{:idx  ["@graph" 0],
-             :id   "http://example.org/library",
-             :type ["http://example.org/vocab#Library"],
-             "http://example.org/vocab#contains"
-             [{:id "http://example.org/library/the-republic", :idx ["@graph" 0 "ex:contains"]}]}
-            {:idx  ["@graph" 1],
-             :id   "http://example.org/library/the-republic",
-             :type ["http://example.org/vocab#Book"],
-             "http://purl.org/dc/elements/1.1/creator"
-             [{:value "Plato", :type nil, :idx ["@graph" 1 "dc11:creator"]}],
-             "http://purl.org/dc/elements/1.1/title"
-             [{:value "The Republic", :type nil, :idx ["@graph" 1 "dc11:title"]}],
-             "http://example.org/vocab#contains"
-             [{:id  "http://example.org/library/the-republic#introduction",
-               :idx ["@graph" 1 "ex:contains"]}]}
-            {:idx  ["@graph" 2],
-             :id   "http://example.org/library/the-republic#introduction",
-             :type ["http://example.org/vocab#Chapter"],
-             "http://purl.org/dc/elements/1.1/description"
-             [{:value "An introductory chapter on The Republic.", :type nil,
-               :idx   ["@graph" 2 "dc11:description"]}],
-             "http://purl.org/dc/elements/1.1/title"
-             [{:value "The Introduction", :type nil,
-               :idx   ["@graph" 2 "dc11:title"]}]}]
-           (into []
-                 (expand/node {"@context" {"dc11"        "http://purl.org/dc/elements/1.1/",
-                                           "ex"          "http://example.org/vocab#",
-                                           "xsd"         "http://www.w3.org/2001/XMLSchema#",
-                                           "ex:contains" {"@type" "@id"}},
-                               "@graph"   [{"@id"         "http://example.org/library",
-                                            "@type"       "ex:Library",
-                                            "ex:contains" "http://example.org/library/the-republic"}
-                                           {"@id"          "http://example.org/library/the-republic",
-                                            "@type"        "ex:Book",
-                                            "dc11:creator" "Plato",
-                                            "dc11:title"   "The Republic",
-                                            "ex:contains"  "http://example.org/library/the-republic#introduction"}
-                                           {"@id"              "http://example.org/library/the-republic#introduction",
-                                            "@type"            "ex:Chapter",
-                                            "dc11:description" "An introductory chapter on The Republic.",
-                                            "dc11:title"       "The Introduction"}]}))))))
+  (testing "Parsing graph nodes"
+    (testing "with a top level default graph"
+      (is (= [{:idx  ["@graph" 0],
+               :id   "http://example.org/library",
+               :type ["http://example.org/vocab#Library"],
+               "http://example.org/vocab#contains"
+               [{:id "http://example.org/library/the-republic", :idx ["@graph" 0 "ex:contains"]}]}
+              {:idx  ["@graph" 1],
+               :id   "http://example.org/library/the-republic",
+               :type ["http://example.org/vocab#Book"],
+               "http://purl.org/dc/elements/1.1/creator"
+               [{:value "Plato", :type nil, :idx ["@graph" 1 "dc11:creator"]}],
+               "http://purl.org/dc/elements/1.1/title"
+               [{:value "The Republic", :type nil, :idx ["@graph" 1 "dc11:title"]}],
+               "http://example.org/vocab#contains"
+               [{:id  "http://example.org/library/the-republic#introduction",
+                 :idx ["@graph" 1 "ex:contains"]}]}
+              {:idx  ["@graph" 2],
+               :id   "http://example.org/library/the-republic#introduction",
+               :type ["http://example.org/vocab#Chapter"],
+               "http://purl.org/dc/elements/1.1/description"
+               [{:value "An introductory chapter on The Republic.", :type nil,
+                 :idx   ["@graph" 2 "dc11:description"]}],
+               "http://purl.org/dc/elements/1.1/title"
+               [{:value "The Introduction", :type nil,
+                 :idx   ["@graph" 2 "dc11:title"]}]}]
+             (into []
+                   (expand/node {"@context" {"dc11"        "http://purl.org/dc/elements/1.1/",
+                                             "ex"          "http://example.org/vocab#",
+                                             "xsd"         "http://www.w3.org/2001/XMLSchema#",
+                                             "ex:contains" {"@type" "@id"}},
+                                 "@graph"   [{"@id"         "http://example.org/library",
+                                              "@type"       "ex:Library",
+                                              "ex:contains" "http://example.org/library/the-republic"}
+                                             {"@id"          "http://example.org/library/the-republic",
+                                              "@type"        "ex:Book",
+                                              "dc11:creator" "Plato",
+                                              "dc11:title"   "The Republic",
+                                              "ex:contains"  "http://example.org/library/the-republic#introduction"}
+                                             {"@id"              "http://example.org/library/the-republic#introduction",
+                                              "@type"            "ex:Chapter",
+                                              "dc11:description" "An introductory chapter on The Republic.",
+                                              "dc11:title"       "The Introduction"}]})))))
+    (testing "with a top level named graph"
+      (is (= {:graph [{"http://example.org/vocab#contains" [{:id "http://example.org/library/the-republic",
+                                                             :idx ["@graph" 0 "ex:contains"]}],
+                       :id "http://example.org/library",
+                       :idx ["@graph" 0],
+                       :type ["http://example.org/vocab#Library"]}
+                      {"http://example.org/vocab#contains" [{:id "http://example.org/library/the-republic#introduction",
+                                                             :idx ["@graph" 1 "ex:contains"]}],
+                       "http://purl.org/dc/elements/1.1/creator" [{:idx ["@graph" 1 "dc11:creator"],
+                                                                   :type nil,
+                                                                   :value "Plato"}],
+                       "http://purl.org/dc/elements/1.1/title" [{:idx ["@graph" 1 "dc11:title"],
+                                                                 :type nil,
+                                                                 :value "The Republic"}],
+                       :id "http://example.org/library/the-republic",
+                       :idx ["@graph" 1],
+                       :type ["http://example.org/vocab#Book"]}
+                      {"http://purl.org/dc/elements/1.1/description" [{:idx ["@graph" 2 "dc11:description"],
+                                                                       :type nil,
+                                                                       :value "An introductory chapter on The Republic."}],
+                       "http://purl.org/dc/elements/1.1/title" [{:idx ["@graph" 2 "dc11:title"],
+                                                                 :type nil,
+                                                                 :value "The Introduction"}],
+                       :id "http://example.org/library/the-republic#introduction",
+                       :idx ["@graph" 2],
+                       :type ["http://example.org/vocab#Chapter"]}],
+              :id "http://example.org/vocab#alexandria",
+              :idx []}
+             (expand/node {"@context" {"dc11"        "http://purl.org/dc/elements/1.1/",
+                                       "ex"          "http://example.org/vocab#",
+                                       "xsd"         "http://www.w3.org/2001/XMLSchema#",
+                                       "ex:contains" {"@type" "@id"}},
+                           "@id"      "ex:alexandria",
+                           "@graph"   [{"@id"         "http://example.org/library",
+                                        "@type"       "ex:Library",
+                                        "ex:contains" "http://example.org/library/the-republic"}
+                                       {"@id"          "http://example.org/library/the-republic",
+                                        "@type"        "ex:Book",
+                                        "dc11:creator" "Plato",
+                                        "dc11:title"   "The Republic",
+                                        "ex:contains"  "http://example.org/library/the-republic#introduction"}
+                                       {"@id"              "http://example.org/library/the-republic#introduction",
+                                        "@type"            "ex:Chapter",
+                                        "dc11:description" "An introductory chapter on The Republic.",
+                                        "dc11:title"       "The Introduction"}]}))))))
 
 
 (deftest list-type-values

--- a/test/fluree/json_ld/impl/expand_test.cljc
+++ b/test/fluree/json_ld/impl/expand_test.cljc
@@ -314,24 +314,26 @@
                        :idx ["@graph" 2],
                        :type ["http://example.org/vocab#Chapter"]}],
               :id "http://example.org/vocab#alexandria",
+              "http://example.org/vocab#burnedAt" [{:idx ["ex:burnedAt"], :type nil, :value "640 CE"}]
               :idx []}
-             (expand/node {"@context" {"dc11"        "http://purl.org/dc/elements/1.1/",
-                                       "ex"          "http://example.org/vocab#",
-                                       "xsd"         "http://www.w3.org/2001/XMLSchema#",
-                                       "ex:contains" {"@type" "@id"}},
-                           "@id"      "ex:alexandria",
-                           "@graph"   [{"@id"         "http://example.org/library",
-                                        "@type"       "ex:Library",
-                                        "ex:contains" "http://example.org/library/the-republic"}
-                                       {"@id"          "http://example.org/library/the-republic",
-                                        "@type"        "ex:Book",
-                                        "dc11:creator" "Plato",
-                                        "dc11:title"   "The Republic",
-                                        "ex:contains"  "http://example.org/library/the-republic#introduction"}
-                                       {"@id"              "http://example.org/library/the-republic#introduction",
-                                        "@type"            "ex:Chapter",
-                                        "dc11:description" "An introductory chapter on The Republic.",
-                                        "dc11:title"       "The Introduction"}]}))
+             (expand/node {"@context"    {"dc11"        "http://purl.org/dc/elements/1.1/",
+                                          "ex"          "http://example.org/vocab#",
+                                          "xsd"         "http://www.w3.org/2001/XMLSchema#",
+                                          "ex:contains" {"@type" "@id"}},
+                           "@id"         "ex:alexandria",
+                           "ex:burnedAt" "640 CE"
+                           "@graph"      [{"@id"         "http://example.org/library",
+                                           "@type"       "ex:Library",
+                                           "ex:contains" "http://example.org/library/the-republic"}
+                                          {"@id"          "http://example.org/library/the-republic",
+                                           "@type"        "ex:Book",
+                                           "dc11:creator" "Plato",
+                                           "dc11:title"   "The Republic",
+                                           "ex:contains"  "http://example.org/library/the-republic#introduction"}
+                                          {"@id"              "http://example.org/library/the-republic#introduction",
+                                           "@type"            "ex:Chapter",
+                                           "dc11:description" "An introductory chapter on The Republic.",
+                                           "dc11:title"       "The Introduction"}]}))
           "retains the named graph's properties"))))
 
 


### PR DESCRIPTION
This patch parses [top-level named graphs](https://www.w3.org/TR/json-ld11/#named-graphs) more in-line with [the playground](https://tinyurl.com/yramr9xm) by retaining the metadata properties defined in the graph. This change is required for environmental profiles in json-ld server configurations to work. 