### PR TITLE
Migrate to tools.build and add automatic npm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 
 SOURCES := $(shell find src)
 
-target/fluree-json-ld.jar: pom.xml deps.edn src/deps.cljs $(SOURCES)
-	clojure -X:jar
+target/json-ld-0.1.0.jar: deps.edn src/deps.cljs $(SOURCES)
+	clojure -T:build jar
 
 src/deps.cljs: package.json
 	clojure -M:js-deps
@@ -34,7 +34,10 @@ browsertest:
 	npx shadow-cljs release browser-test
 	./node_modules/karma/bin/karma start --single-run
 
-cljstest: nodetest browsertest
+node_modules: package.json
+	npm install
+
+cljstest: node_modules nodetest browsertest
 
 test: cljtest cljstest
 
@@ -50,15 +53,15 @@ fmt:
 fmt-check:
 	clojure -M:fmt check
 
-jar: target/fluree-json-ld.jar
+jar: target/json-ld-0.1.0.jar
 
-install: target/fluree-json-ld.jar
-	clojure -X:install
+install: target/json-ld-0.1.0.jar
+	clojure -T:build install
 
 # You'll need to set the env vars CLOJARS_USERNAME & CLOJARS_PASSWORD
 # (which must be a Clojars deploy token now) to use this.
-deploy: target/fluree-json-ld.jar
-	clojure -X:deploy
+deploy: target/json-ld-0.1.0.jar
+	clojure -T:build deploy
 
 clean:
 	rm -rf target

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: test jar install deploy clean edn-contexts parse-all-contexts lint lint-ci fmt fmt-check
+.PHONY: help test jar install deploy clean edn-contexts parse-all-contexts lint lint-ci fmt fmt-check cljtest cljstest nodetest browsertest
 
 SOURCES := $(shell find src)
+
+.PHONY: help
+help: ## Describe available tasks
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help
 
 target/json-ld-0.1.0.jar: deps.edn src/deps.cljs $(SOURCES)
 	clojure -T:build jar
@@ -14,56 +20,56 @@ resources/contexts/%.edn: resources/contexts/%.jsonld
 CONTEXTS := $(shell find resources/contexts -name '*.jsonld')
 EDN_CONTEXTS := $(CONTEXTS:.jsonld=.edn)
 
-edn-contexts: $(EDN_CONTEXTS)
+edn-contexts: $(EDN_CONTEXTS) ## Build EDN versions of JSON-LD context files
 
 # Re-parse all JSON-LD contexts from external.cljc
-parse-all-contexts:
+parse-all-contexts: ## Re-parse all JSON-LD contexts from external sources
 	@echo "Re-parsing all JSON-LD contexts..."
 	@clojure -M:dev scripts/parse-contexts.clj
 
 pom.xml: deps.edn
 	clojure -Spom
 
-cljtest:
+cljtest: ## Run Clojure tests
 	clojure -X:test
 
-nodetest:
+nodetest: ## Run ClojureScript Node.js tests
 	npx shadow-cljs release nodejs-test
 
-browsertest:
+browsertest: ## Run ClojureScript browser tests with Karma
 	npx shadow-cljs release browser-test
 	./node_modules/karma/bin/karma start --single-run
 
 node_modules: package.json
 	npm install
 
-cljstest: node_modules nodetest browsertest
+cljstest: node_modules nodetest browsertest ## Run all ClojureScript tests
 
-test: cljtest cljstest
+test: cljtest cljstest ## Run all tests (Clojure and ClojureScript)
 
-lint:
+lint: ## Run clj-kondo linter
 	clj-kondo --lint src test
 
-lint-ci:
+lint-ci: ## Run clj-kondo linter with CI configuration
 	clj-kondo --config .clj-kondo/ci-config.edn --lint src test
 
-fmt:
+fmt: ## Fix code formatting with cljfmt
 	clojure -M:fmt fix
 
-fmt-check:
+fmt-check: ## Check code formatting with cljfmt
 	clojure -M:fmt check
 
-jar: target/json-ld-0.1.0.jar
+jar: target/json-ld-0.1.0.jar ## Build JAR file
 
-install: target/json-ld-0.1.0.jar
+install: target/json-ld-0.1.0.jar ## Install JAR to local repository
 	clojure -T:build install
 
 # You'll need to set the env vars CLOJARS_USERNAME & CLOJARS_PASSWORD
 # (which must be a Clojars deploy token now) to use this.
-deploy: target/json-ld-0.1.0.jar
+deploy: target/json-ld-0.1.0.jar ## Deploy JAR to Clojars
 	clojure -T:build deploy
 
-clean:
+clean: ## Remove build artifacts
 	rm -rf target
 	rm -rf node_modules
 	rm -rf test/nodejs

--- a/README.md
+++ b/README.md
@@ -203,13 +203,32 @@ Access them directly:
 
 ## Development
 
+### Prerequisites
+
+ClojureScript tests require Node.js and npm. The Makefile will automatically install npm dependencies when running tests.
+
+### Testing
+
 Run the project's tests:
 
 ```bash
-$ make test        # Run all tests
+$ make test        # Run all tests  
 $ make cljtest     # Run Clojure tests only
-$ make cljstest    # Run ClojureScript tests only
+$ make cljstest    # Run ClojureScript tests only (auto-installs npm deps)
 ```
+
+### Code Quality
+
+Lint and format code:
+
+```bash
+$ make lint        # Run clj-kondo linter
+$ make lint-ci     # Run stricter CI linting  
+$ make fmt         # Auto-format code
+$ make fmt-check   # Check formatting without changing files
+```
+
+### Building
 
 Build a deployable jar:
 
@@ -228,6 +247,8 @@ Deploy to Clojars (requires `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` environmen
 ```bash
 $ make deploy
 ```
+
+### Development Tools
 
 Re-parse all external contexts:
 

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,76 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [clojure.string :as str]
+            [deps-deploy.deps-deploy :as dd]))
+
+(def lib 'com.fluree/json-ld)
+(def version "0.1.0")
+(def class-dir "target/classes")
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+;; delay to defer side effects (artifact downloads)
+(def basis (delay (b/create-basis {:project "deps.edn"})))
+
+(defn clean
+  "Delete the build target directory"
+  [_]
+  (println "\nCleaning target...")
+  (b/delete {:path "target"}))
+
+(defn jar
+  "Build the JAR"
+  [_]
+  (clean nil)
+  (println "\nBuilding JAR" jar-file "...")
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis @basis
+                :src-dirs ["src"]
+                :scm {:url "https://github.com/fluree/json-ld"
+                      :connection "scm:git:git://github.com/fluree/json-ld.git"
+                      :developerConnection "scm:git:ssh://git@github.com/fluree/json-ld.git"
+                      :tag (str "v" version)}
+                :pom-data [[:description "A JSON-LD library for Clojure and ClojureScript"]
+                          [:url "https://github.com/fluree/json-ld"]
+                          [:licenses
+                           [:license
+                            [:name "Eclipse Public License 1.0"]
+                            [:url "https://opensource.org/licenses/EPL-1.0"]]]]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file})
+  (println "JAR built successfully!"))
+
+(defn install
+  "Install the JAR locally"
+  [_]
+  (let [jar-file' (b/resolve-path jar-file)]
+    (if (.exists jar-file')
+      (do
+        (println "\nInstalling" jar-file "to local Maven repository...")
+        (b/install {:basis @basis
+                    :lib lib
+                    :version version
+                    :jar-file jar-file
+                    :class-dir class-dir}))
+      (do
+        (println "JAR file not found. Building...")
+        (jar nil)
+        (install nil)))))
+
+(defn deploy
+  "Deploy the JAR to Clojars"
+  [_]
+  (let [jar-file' (b/resolve-path jar-file)]
+    (if (.exists jar-file')
+      (do
+        (println "\nDeploying" jar-file "to Clojars...")
+        (dd/deploy {:installer :remote
+                    :artifact (b/resolve-path jar-file)
+                    :pom-file (b/pom-path {:lib lib :class-dir class-dir})}))
+      (do
+        (println "JAR file not found. Building...")
+        (jar nil)
+        (deploy nil)))))

--- a/deps.edn
+++ b/deps.edn
@@ -32,27 +32,26 @@
   {:extra-deps {com.timetraveltoaster/target-bundle-libs {:mvn/version "RELEASE"}}
    :main-opts  ["-m" "target-bundle-libs.core"]}
 
+  :build
+  {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}
+          slipset/deps-deploy {:mvn/version "0.2.0"}}
+   :ns-default build}
+
   :jar
-  {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
-   :exec-fn      hf.depstar/jar
-   :exec-args    {:jar         "target/fluree-json-ld.jar"
-                  :group-id    :mvn/group-id
-                  :artifact-id :mvn/artifact-id
-                  :version     :mvn/version
-                  :sync-pom    true}}
+  {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}}
+   :ns-default build
+   :exec-fn jar}
 
   :install
-  {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
-   :exec-fn    deps-deploy.deps-deploy/deploy
-   :exec-args  {:installer :local
-                :artifact  "target/fluree-json-ld.jar"}}
+  {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}}
+   :ns-default build
+   :exec-fn install}
 
   :deploy
-  {:extra-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
-   :exec-fn    deps-deploy.deps-deploy/deploy
-   :exec-args  {:installer      :remote
-                :sign-releases? false
-                :artifact       "target/fluree-json-ld.jar"}}
+  {:deps {io.github.clojure/tools.build {:mvn/version "0.9.6"}
+          slipset/deps-deploy {:mvn/version "0.2.0"}}
+   :ns-default build
+   :exec-fn deploy}
 
   :build-edn-context
   {:extra-paths ["dev"]


### PR DESCRIPTION
## Summary
- Migrates from depstar to tools.build for modern Clojure build tooling
- Adds automatic npm dependency installation to prevent test failures
- Updates README documentation with npm/node requirements and new Makefile targets

## Changes
1. **Build System Migration**
   - Replace depstar with tools.build in deps.edn
   - Add build.clj with jar, install, and deploy functions
   - Update Makefile to use new build commands

2. **Automatic npm Install**
   - Add node_modules target to Makefile that runs when package.json changes
   - Make cljstest depend on node_modules
   - Prevents "npm not found" errors during ClojureScript tests

3. **Documentation Updates**
   - Add Prerequisites section documenting Node.js/npm requirements
   - Add Code Quality section with lint and fmt commands
   - Better organize Development section with subsections

## Test plan
- [x] Run `make clean && make test` - all tests pass
- [x] Run `make lint` - no warnings
- [x] Run `make jar` - builds successfully
- [x] Verify npm auto-installs when running cljstest