### PR TITLE
Release v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## Describe available tasks
 
 .DEFAULT_GOAL := help
 
-target/json-ld-0.1.0.jar: deps.edn src/deps.cljs $(SOURCES)
+target/json-ld-1.0.0.jar: deps.edn src/deps.cljs $(SOURCES)
 	clojure -T:build jar
 
 src/deps.cljs: package.json
@@ -59,14 +59,14 @@ fmt: ## Fix code formatting with cljfmt
 fmt-check: ## Check code formatting with cljfmt
 	clojure -M:fmt check
 
-jar: target/json-ld-0.1.0.jar ## Build JAR file
+jar: target/json-ld-1.0.0.jar ## Build JAR file
 
-install: target/json-ld-0.1.0.jar ## Install JAR to local repository
+install: target/json-ld-1.0.0.jar ## Install JAR to local repository
 	clojure -T:build install
 
 # You'll need to set the env vars CLOJARS_USERNAME & CLOJARS_PASSWORD
 # (which must be a Clojars deploy token now) to use this.
-deploy: target/json-ld-0.1.0.jar ## Deploy JAR to Clojars
+deploy: target/json-ld-1.0.0.jar ## Deploy JAR to Clojars
 	clojure -T:build deploy
 
 clean: ## Remove build artifacts

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## Describe available tasks
 
 .DEFAULT_GOAL := help
 
-target/json-ld-1.0.0.jar: deps.edn src/deps.cljs $(SOURCES)
+target/fluree-json-ld.jar: deps.edn src/deps.cljs $(SOURCES)
 	clojure -T:build jar
 
 src/deps.cljs: package.json
@@ -59,14 +59,14 @@ fmt: ## Fix code formatting with cljfmt
 fmt-check: ## Check code formatting with cljfmt
 	clojure -M:fmt check
 
-jar: target/json-ld-1.0.0.jar ## Build JAR file
+jar: target/fluree-json-ld.jar ## Build JAR file
 
-install: target/json-ld-1.0.0.jar ## Install JAR to local repository
+install: target/fluree-json-ld.jar ## Install JAR to local repository
 	clojure -T:build install
 
 # You'll need to set the env vars CLOJARS_USERNAME & CLOJARS_PASSWORD
 # (which must be a Clojars deploy token now) to use this.
-deploy: target/json-ld-1.0.0.jar ## Deploy JAR to Clojars
+deploy: target/fluree-json-ld.jar ## Deploy JAR to Clojars
 	clojure -T:build deploy
 
 clean: ## Remove build artifacts

--- a/build.clj
+++ b/build.clj
@@ -4,7 +4,7 @@
             [deps-deploy.deps-deploy :as dd]))
 
 (def lib 'com.fluree/json-ld)
-(def version "0.1.0")
+(def version "1.0.0")
 (def class-dir "target/classes")
 (def jar-file (format "target/%s-%s.jar" (name lib) version))
 

--- a/build.clj
+++ b/build.clj
@@ -6,7 +6,7 @@
 (def lib 'com.fluree/json-ld)
 (def version "1.0.0")
 (def class-dir "target/classes")
-(def jar-file (format "target/%s-%s.jar" (name lib) version))
+(def jar-file "target/fluree-json-ld.jar")
 
 ;; delay to defer side effects (artifact downloads)
 (def basis (delay (b/create-basis {:project "deps.edn"})))


### PR DESCRIPTION
## Summary
- Bump version to 1.0.0 for first stable release
- Update build process to use consistent JAR filename (target/fluree-json-ld.jar)
- Align with fluree/db build conventions

## Changes
- Version updated to 1.0.0 in build.clj
- JAR filename standardized to `target/fluree-json-ld.jar` (version-independent)
- Makefile updated to reference new JAR filename

## Release Process
After this PR is merged:
1. Tag the merge commit as v1.0.0
2. Create GitHub release from the tag
3. Deploy to Clojars

/cc @fluree/core